### PR TITLE
Changes AreaChart to take a single TimeSeries

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This library contains a set of modular charting components used for building flexible interactive charts. It was built for React from the ground up, specifically to visualize timeseries data and network traffic data in particular. Low level elements are constructed using d3, while higher level composability is provided by React. Charts can be stacked as rows, overlayed on top of each other, or any combination, all in a highly declarative manner.
 
-The library is used thoughout the public facing [ESnet Portal](http://my.es.net).
+The library is used throughout the public facing [ESnet Portal](http://my.es.net).
 
 Current features of the library include:
 
@@ -23,7 +23,7 @@ Please browse the examples for a feel for the library, or read on to get started
 Getting started
 ---------------
 
-The charts library is intended to be used with npm and the built into your project with something like webpack.
+The charts library is intended to be used with [npm](https://www.npmjs.com/) and the built into your project with something like [Webpack](https://webpack.github.io/). In addition, it currently assumes that [Bootstrap](http://getbootstrap.com/) is present on the page.
 
     npm install @esnet/react-timeseries-charts --save
 

--- a/docs/areachart.md
+++ b/docs/areachart.md
@@ -31,7 +31,7 @@ Note: It is recommended that `<ChartContainer>`s be placed within a `<Resizable>
 
 #### axis
 
-Reference to the axis which provides the vertical scale for ## drawing. In the above example, the `axis="traffic"` refers to the YAxis of `id="traffic"`.
+Reference to the axis which provides the vertical scale for the chart rendering. In the above example, the `axis="traffic"` refers to the YAxis of `id="traffic"`.
 
 #### series
 

--- a/docs/areachart.md
+++ b/docs/areachart.md
@@ -1,32 +1,52 @@
 
-The AreaChart widget is able to display an area above or below the axis, as well as stacking in each direction. It used throughout the My ESnet Portal.
+The AreaChart widget is able to display single or multiple stacked areas above or below the axis. It used throughout the My ESnet Portal.
 
-The AreaChart should be used within `<ChartContainer />`, as this will construct the horizontal and vertical axis, and manage other elements. Here is an example of an AreaChart with an up and down traffic visualization:
+The AreaChart should be used within a `<ChartContainer />` structure, as this will construct the horizontal and vertical axis, and manage other elements. Here is an example of an AreaChart with an up and down traffic visualization:
 
 ```js
-    <ChartContainer timeRange={timerange}>
-        <ChartRow height="150">
-            <Charts>
-                <AreaChart axis="traffic" series={[[inSeries],[outSeries]]} />
-            </Charts>
-            <YAxis id="traffic" label="Traffic (bps)" min={-max} max={max} absolute={true} width="60" type="linear"/>
-        </ChartRow>
-    </ChartContainer>
+    render() {
+        return (
+            ...
+            <ChartContainer timeRange={trafficSeries.range()} width="1080">
+                <ChartRow height="150">
+                    <Charts>
+                        <AreaChart
+                            axis="traffic"
+                            series={trafficSeries}
+                            columns={{up: ["in"], down: ["out"]}}/>
+                    </Charts>
+                    <YAxis id="traffic" label="Traffic (bps)" min={-max} max={max} absolute={true} width="60" type="linear"/>
+                </ChartRow>
+            </ChartContainer>
+            ...
+        );
+    }
 ```
+
+The `<AreaChart>` takes a single TimeSeries object into its `series` prop. This series can multiple columns and those columns can be referenced using the `columns` prop. The `columns` props allows you to map columns in the series to the chart, letting you specify the stacking and orientation of the data. In the above example we map the "in" column in trafficSeries to the up direction and the "out" column to the down direction. Each direction is specified as an array, so adding multiple columns into a direction is what causes the stacking in that direction.
+
+Note: It is recommended that `<ChartContainer>`s be placed within a `<Resizable>` tag, rather than hard coding the width as in the above example.
 
 ### Props
 
 #### axis
 
-Reference to the axis which provides the vertical scale for ## drawing. In the above case the axis="traffic", which refers to the YAxis of id="traffic".
+Reference to the axis which provides the vertical scale for ## drawing. In the above example, the `axis="traffic"` refers to the YAxis of `id="traffic"`.
 
 #### series
 
-What data to draw. The format is an tuple of [up, down], when up and down are the directions to draw in. Both up and down are themselves arrays which specify the stacking of the areas in that direction. Each member of that array needs to be a [Pond TimeSeries](http://software.es.net/pond/#/timeseries), and that TimeSeries needs to have a "value" column which is used as the source of data.
+What [Pond TimeSeries](http://software.es.net/pond/#/timeseries) data to visualize.
 
-#### interpolate
+#### columns
 
-The style to draw the chart. This is the [d3 interpolation mode](https://github.com/mbostock/d3/wiki/SVG-Shapes#line_interpolate)
+Provides the mapping of the series columns to the stacking order and direction. As an example, say we had network traffic that is either "in" or "out. We'll display the "in" traffic above the axis and the "out" traffic below the axis. Further, we want to break down the "in" and "out" traffic by its type ("oscars", "lhcone", or "other") and then stack those on top of each other. The column mapping would look like this:
+
+```js
+const columns = {
+    up:   ["oscarsTrafficIn", "lhconeTrafficIn", "otherTrafficIn"],
+    down: ["oscarsTrafficOut", "lhconeTrafficOut", "otherTrafficOut"],
+}
+```
 
 #### style
 
@@ -40,4 +60,10 @@ const style = {
 ```
 
 Where each color in the array corresponds to each area stacked either up or down.
+
+#### interpolate
+
+The style to draw the chart. This is the [d3 interpolation mode](https://github.com/mbostock/d3/wiki/SVG-Shapes#line_interpolate)
+
+
 

--- a/examples/modules/areachart.jsx
+++ b/examples/modules/areachart.jsx
@@ -16,7 +16,7 @@ import Markdown from "react-markdown";
 import Highlighter from "./highlighter";
 
 // Pond
-import {TimeSeries, TimeRange} from "@esnet/pond";
+import {TimeSeries} from "@esnet/pond";
 
 // Imports from the charts library
 import Legend from "../../src/legend";
@@ -25,7 +25,6 @@ import ChartRow from "../../src/chartrow";
 import Charts from "../../src/charts";
 import YAxis from "../../src/yaxis";
 import AreaChart from "../../src/areachart";
-import TimeRangeMarker from "../../src/timerangemarker";
 import Resizable from "../../src/resizable";
 
 // Docs text
@@ -34,20 +33,22 @@ import exampleText from "raw!../../docs/areachart.md";
 // Data
 const rawTrafficData = require("../data/link-traffic.json");
 
-/**
- * The area chart expects a Timeseries with a simple "value" column
- */
 const trafficBNLtoNEWYSeries = new TimeSeries({
     name: `BNL to NEWY`,
-    columns: ["time", "value"],
+    columns: ["time", "in"],
     points: _.map(rawTrafficData.traffic["BNL--NEWY"], p => [p[0] * 1000, p[1]])
 });
 
 const trafficNEWYtoBNLSeries = new TimeSeries({
     name: `NEWY to BNL`,
-    columns: ["time", "value"],
+    columns: ["time", "out"],
     points: _.map(rawTrafficData.traffic["NEWY--BNL"], p => [p[0] * 1000, p[1]])
 });
+
+const traffic = TimeSeries.merge(
+    {name: "traffic"},
+    [trafficBNLtoNEWYSeries, trafficNEWYtoBNLSeries]
+);
 
 export default React.createClass({
 
@@ -57,7 +58,7 @@ export default React.createClass({
         return {
             markdown: exampleText,
             tracker: null,
-            timerange: trafficBNLtoNEWYSeries.range()
+            timerange: traffic.range()
         };
     },
 
@@ -67,16 +68,6 @@ export default React.createClass({
 
     handleTimeRangeChange(timerange) {
         this.setState({timerange: timerange});
-    },
-
-    renderNightTime() {
-        const sunset = new Date(2015, 7, 31, 19, 36, 0);
-        const sunrise = new Date(2015, 8, 1, 6, 41, 0);
-        const night = new TimeRange(sunset, sunrise);
-
-        return (
-            <TimeRangeMarker timerange={night} style={{fill: "#F3F3F3"}}/>
-        );
     },
 
     render() {
@@ -89,8 +80,8 @@ export default React.createClass({
         };
 
         const max = _.max([
-            trafficBNLtoNEWYSeries.max(),
-            trafficNEWYtoBNLSeries.max()
+            trafficBNLtoNEWYSeries.max("in"),
+            trafficNEWYtoBNLSeries.max("out")
         ]);
 
         const axistype = "linear";
@@ -121,19 +112,21 @@ export default React.createClass({
                     <div className="col-md-12">
                         <Resizable>
 
-                            <ChartContainer timeRange={this.state.timerange}
-                                            trackerPosition={this.state.tracker}
-                                            onTrackerChanged={this.handleTrackerChanged}
-                                            enablePanZoom={true}
-                                            maxTime={trafficBNLtoNEWYSeries.range().end()}
-                                            minTime={trafficBNLtoNEWYSeries.range().begin()}
-                                            minDuration={1000 * 60 * 60}
-                                            onTimeRangeChanged={this.handleTimeRangeChange}
-                                            padding="0"
-                                            transition="300">
+                            <ChartContainer
+                                timeRange={this.state.timerange}
+                                trackerPosition={this.state.tracker}
+                                onTrackerChanged={this.handleTrackerChanged}
+                                enablePanZoom={true}
+                                maxTime={traffic.range().end()}
+                                minTime={traffic.range().begin()}
+                                minDuration={1000 * 60 * 60}
+                                onTimeRangeChanged={this.handleTimeRangeChange} >
                                 <ChartRow height="150" debug={false}>
                                     <Charts>
-                                        <AreaChart axis="traffic" series={[[trafficBNLtoNEWYSeries],[trafficNEWYtoBNLSeries]]} />
+                                        <AreaChart
+                                            axis="traffic"
+                                            series={traffic}
+                                            columns={{up: ["in"], down: ["out"]}} />
                                     </Charts>
                                     <YAxis id="traffic" label="Traffic (bps)" labelOffset={0} min={-max} max={max} absolute={true} width="60" type={axistype}/>
                                 </ChartRow>

--- a/examples/modules/areachart.jsx
+++ b/examples/modules/areachart.jsx
@@ -71,10 +71,9 @@ export default React.createClass({
     },
 
     render() {
-        const dateRangeStyle = {
+        const dateStyle = {
             fontSize: 12,
             color: "#AAA",
-            borderBottomStyle: "solid",
             borderWidth: "1",
             borderColor: "#F4F4F4"
         };
@@ -85,6 +84,7 @@ export default React.createClass({
         ]);
 
         const axistype = "linear";
+        const tracker = this.state.tracker ? `${this.state.tracker}` : "";
 
         return (
             <div>
@@ -102,7 +102,7 @@ export default React.createClass({
                         ]} />
                     </div>
                     <div className="col-md-8">
-                        <span style={dateRangeStyle}>{trafficBNLtoNEWYSeries.range().humanize()}</span>
+                        <span style={dateStyle}>{tracker}</span>
                     </div>
                 </div>
 

--- a/examples/modules/baseline.jsx
+++ b/examples/modules/baseline.jsx
@@ -24,7 +24,6 @@ import Charts from "../../src/charts";
 import YAxis from "../../src/yaxis";
 import LineChart from "../../src/linechart";
 import Baseline from "../../src/baseline";
-import Legend from "../../src/legend";
 import Resizable from "../../src/resizable";
 
 // Docs text
@@ -64,7 +63,6 @@ export default React.createClass({
     },
 
     render() {
-        console.log(series.stdev());
         return (
             <div>
                 <div className="row">
@@ -81,8 +79,8 @@ export default React.createClass({
                                     <Charts>
                                         <LineChart axis="price" series={series} style={style}/>
                                         <Baseline axis="price" value={series.avg()} label="Avg" position="right"/>
-                                        <Baseline axis="price" value={series.avg()-series.stdev()}/>
-                                        <Baseline axis="price" value={series.avg()+series.stdev()}/>
+                                        <Baseline axis="price" value={series.avg() - series.stdev()}/>
+                                        <Baseline axis="price" value={series.avg() + series.stdev()}/>
                                     </Charts>
                                 </ChartRow>
                             </ChartContainer>

--- a/examples/modules/stacked.jsx
+++ b/examples/modules/stacked.jsx
@@ -50,12 +50,29 @@ to any of d3's interpolate functions, in this case 'linear'.
 // Data
 const rawData = require("../data/stacked.json");
 
-const seriesList = _.map(rawData, d => {
-    return new TimeSeries({
-        name: `${d.key}`,
-        columns: ["time", "value"],
-        points: d.values
+const numPoints = rawData[0].values.length;
+
+const columns = ["time"];
+const displayColumns = [];
+_.each(rawData, d => {
+    columns.push(d.key);
+    displayColumns.push(d.key);
+});
+
+const points = [];
+for (let i = 0; i < numPoints; i++) {
+    const t = rawData[0].values[i][0];
+    const point = [t];
+    _.each(rawData, d => {
+        point.push(d.values[i][1]);
     });
+    points.push(point);
+}
+
+const series = new TimeSeries({
+    name: "Stacked",
+    columns: columns,
+    points: points
 });
 
 const countriesList = _.map(rawData, d => {
@@ -86,9 +103,12 @@ export default React.createClass({
     },
 
     render() {
-        const style = {up: colorsList};
+        const style = {up: colorsList, down: []};
+        const cols = {up: displayColumns, down: []};
+        const min = 0;
         const max = 130;
-        const axistype = "linear";
+        const axisType = "linear";
+        const interpolationType = "linear";
 
         return (
             <div>
@@ -110,11 +130,20 @@ export default React.createClass({
                     <div className="col-md-12">
                         <Resizable>
 
-                            <ChartContainer timeRange={seriesList[0].range()} padding="0" transition="300" enablePanZoom={true} >
-                                <ChartRow height="350" debug={false}>
-                                    <YAxis id="value" label="" labelOffset={0} max={max} width="60" type={axistype}/>
+                            <ChartContainer timeRange={series.range()}>
+                                <ChartRow height="350">
+                                    <YAxis
+                                        id="value"
+                                        min={min} max={max}
+                                        width="60"
+                                        type={axisType}/>
                                     <Charts>
-                                        <AreaChart axis="value" style={style} series={[seriesList,[]]} interpolate="linear"/>
+                                        <AreaChart
+                                            axis="value"
+                                            style={style}
+                                            series={series}
+                                            columns={cols}
+                                            interpolate={interpolationType} />
                                     </Charts>
                                 </ChartRow>
                             </ChartContainer>

--- a/examples/modules/weather.jsx
+++ b/examples/modules/weather.jsx
@@ -68,7 +68,7 @@ This example uses three rows to create stacked chart:
             <YAxis id="rain" label="Precipitation (in)" labelOffset={-5} style={{labelColor: scheme.rain}}
                    min={0} max={rainSeries.max()} width="60" type="linear" format=",.2f"/>
             <Charts>
-                <AreaChart axis="rain" series={[[rainSeries],[]]} style={{up: [scheme.rain]}} interpolate="basis"/>
+                <AreaChart axis="rain" series={rainSeries} style={{up: [scheme.rain]}} interpolate="basis"/>
                 <LineChart axis="total-rain" series={rainAccumSeries} style={{color: scheme.rainAccum, width: 1}} />
             </Charts>
             <YAxis id="total-rain" label="Total Precipitation (in)" labelOffset={5} min={0} max={rainAccumSeries.max()} width="60" type="linear" format=",.2f"/>
@@ -188,7 +188,7 @@ export default React.createClass({
                                     <YAxis id="rain" label="Precipitation (in)" classed="rain" labelOffset={-5} style={{labelColor: scheme.rain}}
                                            min={0} max={rainSeries.max()} width="60" type="linear" format=",.2f"/>
                                     <Charts>
-                                        <AreaChart axis="rain" series={[[rainSeries],[]]} style={{up: [scheme.rain]}} interpolate="basis"/>
+                                        <AreaChart axis="rain" series={rainSeries} style={{up: [scheme.rain]}} interpolate="basis"/>
                                         <LineChart axis="total-rain" series={rainAccumSeries} style={{color: scheme.rainAccum, width: 1}} />
                                     </Charts>
                                     <YAxis id="total-rain" label="Total Precipitation (in)" labelOffset={5} min={0} max={rainAccumSeries.max()} width="60" type="linear" format=",.2f"/>

--- a/lib/areachart.js
+++ b/lib/areachart.js
@@ -39,27 +39,29 @@ function scaleAsString(scale) {
  * direction, layer, we have layer.values = [points] where each point is
  * in the format {data: .., value, ..}
  */
-function getLayers(seriesList) {
+function getLayers(columns, series) {
+    var up = columns.up || [];
+    var down = columns.down || [];
     return {
-        upLayers: seriesList[0].map(function (series) {
+        upLayers: up.map(function (columnName) {
             var points = [];
             for (var i = 0; i < series.size(); i++) {
                 var point = series.at(i);
                 points.push({
                     date: point.timestamp(),
-                    value: point.get()
+                    value: point.get(columnName)
                 });
             }
             return { values: points };
         }),
 
-        downLayers: seriesList[1].map(function (series) {
+        downLayers: down.map(function (columnName) {
             var points = [];
             for (var i = 0; i < series.size(); i++) {
                 var point = series.at(i);
                 points.push({
                     date: point.timestamp(),
-                    value: point.get()
+                    value: point.get(columnName)
                 });
             }
             return { values: points };
@@ -123,17 +125,12 @@ function getAreaStackers() {
     };
 }
 
-function getCroppedSeries(scale, width, seriesList) {
+function getCroppedSeries(scale, width, series) {
     var beginTime = scale.invert(0);
     var endTime = scale.invert(width);
-    return _underscore2["default"].map(seriesList, function (direction) {
-        return _underscore2["default"].map(direction, function (series) {
-            var beginIndex = series.bisect(beginTime);
-            var endIndex = series.bisect(endTime);
-            var cropped = series.slice(beginIndex, endIndex === series.size() - 1 ? endIndex : endIndex + 1);
-            return cropped;
-        });
-    });
+    var beginIndex = series.bisect(beginTime);
+    var endIndex = series.bisect(endTime);
+    return series.slice(beginIndex, endIndex === series.size() - 1 ? endIndex : endIndex + 1);
 }
 
 /**
@@ -144,15 +141,25 @@ exports["default"] = _reactAddons2["default"].createClass({
     displayName: "AreaChart",
 
     propTypes: {
-        /**
-         * Time in ms to transition the chart when the axis changes scale
-         */
-        transition: _reactAddons2["default"].PropTypes.number,
 
         /**
-         * The d3 interpolation method
+         * The TimeSeries to render
          */
-        interpolate: _reactAddons2["default"].PropTypes.string,
+        series: _reactAddons2["default"].PropTypes.instanceOf(_esnetPond.TimeSeries).isRequired,
+
+        /**
+         * The series series columns mapped to stacking up and down.
+         * Has the format:
+         *
+         *  "columns": {
+         *      up: ["in", ...],
+         *      down: ["out", ...]
+         *  }
+         */
+        columns: _reactAddons2["default"].PropTypes.shape({
+            up: _reactAddons2["default"].PropTypes.arrayOf(_reactAddons2["default"].PropTypes.string),
+            down: _reactAddons2["default"].PropTypes.arrayOf(_reactAddons2["default"].PropTypes.string)
+        }),
 
         /**
          * The style of the area chart, with format:
@@ -171,11 +178,14 @@ exports["default"] = _reactAddons2["default"].createClass({
         }),
 
         /**
-         * The series list. This is a 2 element array, with the first element
-         * build stacked up and the second element being stacked down. Each
-         * element is itself an array of TimeSeries.
+         * Time in ms to transition the chart when the axis changes scale
          */
-        series: _reactAddons2["default"].PropTypes.arrayOf(_reactAddons2["default"].PropTypes.arrayOf(_reactAddons2["default"].PropTypes.instanceOf(_esnetPond.TimeSeries)))
+        transition: _reactAddons2["default"].PropTypes.number,
+
+        /**
+         * The d3 interpolation method
+         */
+        interpolate: _reactAddons2["default"].PropTypes.string
     },
 
     getDefaultProps: function getDefaultProps() {
@@ -185,6 +195,10 @@ exports["default"] = _reactAddons2["default"].createClass({
             style: {
                 up: ["#448FDD", "#75ACE6", "#A9CBEF"],
                 down: ["#FD8D0D", "#FDA949", "#FEC686"]
+            },
+            columns: {
+                up: ["value"],
+                down: []
             }
         };
     },
@@ -199,7 +213,7 @@ exports["default"] = _reactAddons2["default"].createClass({
     renderAreaChart: function renderAreaChart(series, timeScale, yScale, interpolate, isPanning) {
         var _this = this;
 
-        if (!yScale || !series[0]) {
+        if (!yScale) {
             return null;
         }
 
@@ -212,16 +226,17 @@ exports["default"] = _reactAddons2["default"].createClass({
         var upArea = _getAreaGenerators.upArea;
         var downArea = _getAreaGenerators.downArea;
 
-        var _getLayers = getLayers(croppedSeries);
+        var _getLayers = getLayers(this.props.columns, croppedSeries);
 
         var upLayers = _getLayers.upLayers;
         var downLayers = _getLayers.downLayers;
 
         var _getAreaStackers = getAreaStackers();
 
-        // Stack our layers
         var stackUp = _getAreaStackers.stackUp;
         var stackDown = _getAreaStackers.stackDown;
+
+        // Stack our layers
         stackUp(upLayers);
         if (downLayers.length) {
             stackDown(downLayers);
@@ -271,16 +286,17 @@ exports["default"] = _reactAddons2["default"].createClass({
         var upArea = _getAreaGenerators2.upArea;
         var downArea = _getAreaGenerators2.downArea;
 
-        var _getLayers2 = getLayers(croppedSeries);
+        var _getLayers2 = getLayers(this.props.columns, croppedSeries);
 
         var upLayers = _getLayers2.upLayers;
         var downLayers = _getLayers2.downLayers;
 
         var _getAreaStackers2 = getAreaStackers();
 
-        // Stack our layers
         var stackUp = _getAreaStackers2.stackUp;
         var stackDown = _getAreaStackers2.stackDown;
+
+        // Stack our layers
         stackUp(upLayers);
         if (downLayers.length) {
             stackDown(downLayers);
@@ -309,25 +325,17 @@ exports["default"] = _reactAddons2["default"].createClass({
 
         var isPanning = nextProps.isPanning;
 
-        // What changed
+        // What changed?
         var timeScaleChanged = scaleAsString(this.props.timeScale) !== scaleAsString(timeScale);
         var yAxisScaleChanged = scaleAsString(this.props.yScale) !== scaleAsString(yScale);
         var interpolateChanged = this.props.interpolate !== interpolate;
         var isPanningChanged = this.props.isPanning !== isPanning;
 
         var seriesChanged = false;
-        if (oldSeries[0].length !== newSeries[0].length || oldSeries[0].length !== newSeries[0].length) {
+        if (oldSeries.length !== newSeries.length) {
             seriesChanged = true;
         } else {
-            for (var d = 0; d < 2; d++) {
-                for (var a = 0; a < oldSeries[d].length; a++) {
-                    var o = oldSeries[d][a];
-                    var n = newSeries[d][a];
-                    if (!_esnetPond.TimeSeries.is(o, n)) {
-                        seriesChanged = true;
-                    }
-                }
-            }
+            seriesChanged = _esnetPond.TimeSeries.is(oldSeries, newSeries);
         }
 
         //

--- a/lib/areachart.js
+++ b/lib/areachart.js
@@ -335,7 +335,7 @@ exports["default"] = _reactAddons2["default"].createClass({
         if (oldSeries.length !== newSeries.length) {
             seriesChanged = true;
         } else {
-            seriesChanged = _esnetPond.TimeSeries.is(oldSeries, newSeries);
+            seriesChanged = !_esnetPond.TimeSeries.is(oldSeries, newSeries);
         }
 
         //

--- a/lib/chartcontainer.js
+++ b/lib/chartcontainer.js
@@ -36,9 +36,9 @@ var _reactLibInvariant2 = _interopRequireDefault(_reactLibInvariant);
 
 var _timeaxis = require("./timeaxis");
 
-//eslint-disable-line
-
 var _timeaxis2 = _interopRequireDefault(_timeaxis);
+
+//eslint-disable-line
 
 var _chartrow = require("./chartrow");
 

--- a/lib/chartrow.js
+++ b/lib/chartrow.js
@@ -42,11 +42,13 @@ var _brush2 = _interopRequireDefault(_brush);
 
 var _tracker = require("./tracker");
 
-//eslint-disable-line
-
 var _tracker2 = _interopRequireDefault(_tracker);
 
+//eslint-disable-line
+
 var _eventhandler = require("./eventhandler");
+
+var _eventhandler2 = _interopRequireDefault(_eventhandler);
 
 //eslint-disable-line
 
@@ -54,9 +56,6 @@ var _eventhandler = require("./eventhandler");
  * A ChartRow has a set of Y axes and multiple charts which are overlayed
  * on each other in a central canvas.
  */
-
-var _eventhandler2 = _interopRequireDefault(_eventhandler);
-
 exports["default"] = _reactAddons2["default"].createClass({
 
     displayName: "ChartRow",

--- a/lib/charts.js
+++ b/lib/charts.js
@@ -22,6 +22,8 @@ var _reactAddons2 = _interopRequireDefault(_reactAddons);
 
 var _reactLibInvariant = require("react/lib/invariant");
 
+var _reactLibInvariant2 = _interopRequireDefault(_reactLibInvariant);
+
 /**
  * A Charts component is a grouping of charts which will be composited on top of
  * each other. It does no actual rendering itself, but instead is used for
@@ -30,9 +32,6 @@ var _reactLibInvariant = require("react/lib/invariant");
  * be at least one, are considered a chart. They should return an SVG <g>
  * containing their render.
  */
-
-var _reactLibInvariant2 = _interopRequireDefault(_reactLibInvariant);
-
 exports["default"] = _reactAddons2["default"].createClass({
 
     displayName: "Charts",

--- a/lib/eventhandler.js
+++ b/lib/eventhandler.js
@@ -22,10 +22,6 @@ var _reactAddons2 = _interopRequireDefault(_reactAddons);
 
 var _esnetPond = require("@esnet/pond");
 
-var _jquery = require("jquery");
-
-var _jquery2 = _interopRequireDefault(_jquery);
-
 // http://stackoverflow.com/a/28857255
 function getElementOffset(element) {
     var de = document.documentElement;

--- a/lib/eventhandler.js
+++ b/lib/eventhandler.js
@@ -26,6 +26,18 @@ var _jquery = require("jquery");
 
 var _jquery2 = _interopRequireDefault(_jquery);
 
+// http://stackoverflow.com/a/28857255
+function getElementOffset(element) {
+    var de = document.documentElement;
+    var box = element.getBoundingClientRect();
+    var top = box.top + window.pageYOffset - de.clientTop;
+    var left = box.left + window.pageXOffset - de.clientLeft;
+    return {
+        top: top,
+        left: left
+    };
+}
+
 exports["default"] = _reactAddons2["default"].createClass({
 
     displayName: "EventHandler",
@@ -39,10 +51,12 @@ exports["default"] = _reactAddons2["default"].createClass({
         };
     },
 
+    // get the event mouse position relative to the event rect
     getOffsetMousePosition: function getOffsetMousePosition(e) {
-        var target = e.currentTarget;
-        var x = e.pageX - (0, _jquery2["default"])(target).offset().left;
-        var y = e.pageY - (0, _jquery2["default"])(target).offset().top;
+        var trackerRect = _reactAddons2["default"].findDOMNode(this.refs.eventrect);
+        var offset = getElementOffset(trackerRect);
+        var x = e.pageX - offset.left;
+        var y = e.pageY - offset.top;
         return [Math.round(x), Math.round(y)];
     },
 
@@ -133,6 +147,7 @@ exports["default"] = _reactAddons2["default"].createClass({
 
     handleMouseOut: function handleMouseOut(e) {
         e.preventDefault();
+
         if (this.props.onMouseOut) {
             this.props.onMouseOut();
         }
@@ -171,9 +186,8 @@ exports["default"] = _reactAddons2["default"].createClass({
                 this.props.onZoom(newTimeRange);
             }
         } else if (this.props.onMouseMove) {
-            var target = e.currentTarget;
-            var xx = e.pageX - (0, _jquery2["default"])(target).offset().left;
-            var time = this.props.scale.invert(xx);
+            var trackerPosition = this.getOffsetMousePosition(e)[0];
+            var time = this.props.scale.invert(trackerPosition);
 
             // onMouseMove callback
             if (this.props.onMouseMove) {
@@ -198,6 +212,7 @@ exports["default"] = _reactAddons2["default"].createClass({
                 onMouseOut: this.handleMouseOut,
                 onMouseUp: this.handleMouseUp },
             _reactAddons2["default"].createElement("rect", { key: "handler-hit-rect",
+                ref: "eventrect",
                 style: { opacity: 0.0, cursor: cursor },
                 x: 0, y: 0,
                 width: this.props.width, height: this.props.height }),

--- a/lib/labelaxis.js
+++ b/lib/labelaxis.js
@@ -26,6 +26,8 @@ var _d32 = _interopRequireDefault(_d3);
 
 var _underscore = require("underscore");
 
+var _underscore2 = _interopRequireDefault(_underscore);
+
 /**
  * Renders a 'axis' that display a label for a data channel and a
  * max and average value
@@ -38,8 +40,6 @@ var _underscore = require("underscore");
  * EXPERIMENTAL
  *
  */
-
-var _underscore2 = _interopRequireDefault(_underscore);
 
 exports["default"] = _reactAddons2["default"].createClass({
 

--- a/lib/resizable.js
+++ b/lib/resizable.js
@@ -18,14 +18,13 @@ Object.defineProperty(exports, '__esModule', {
 
 var _reactAddons = require("react/addons");
 
+var _reactAddons2 = _interopRequireDefault(_reactAddons);
+
 /**
  * This takes a single child and inserts a prop 'width' on it that is the
  * current width of the this container. This is handy if you want to surround
  * a chart or other svg diagram and have this drive the chart width.
  */
-
-var _reactAddons2 = _interopRequireDefault(_reactAddons);
-
 exports['default'] = _reactAddons2['default'].createClass({
     displayName: 'resizable',
 

--- a/lib/valueaxis.js
+++ b/lib/valueaxis.js
@@ -18,6 +18,8 @@ Object.defineProperty(exports, "__esModule", {
 
 var _reactAddons = require("react/addons");
 
+var _reactAddons2 = _interopRequireDefault(_reactAddons);
+
 /**
  * Renders a 'axis' that display a label for a current tracker value
  *
@@ -29,9 +31,6 @@ var _reactAddons = require("react/addons");
  *
  *  EXPERIMENTAL
  */
-
-var _reactAddons2 = _interopRequireDefault(_reactAddons);
-
 exports["default"] = _reactAddons2["default"].createClass({
 
     displayName: "ValueAxis",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "license": "BSD-3-Clause-LBNL",
   "dependencies": {
-    "@esnet/pond": "^0.1.3",
+    "@esnet/pond": "^0.2.x",
     "babel-runtime": "~5.8.3",
     "d3": "^3.5.5",
     "jquery": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "@esnet/pond": "^0.2.x",
     "babel-runtime": "~5.8.3",
     "d3": "^3.5.5",
-    "jquery": "^2.1.4",
     "merge": "^1.2.0",
     "moment": "^2.8.4",
     "paths-js": "^0.3.4",

--- a/src/areachart.jsx
+++ b/src/areachart.jsx
@@ -317,7 +317,7 @@ export default React.createClass({
         if (oldSeries.length !== newSeries.length) {
             seriesChanged = true;
         } else {
-            seriesChanged = TimeSeries.is(oldSeries, newSeries);
+            seriesChanged = !TimeSeries.is(oldSeries, newSeries);
         }
 
         //

--- a/src/eventhandler.jsx
+++ b/src/eventhandler.jsx
@@ -10,14 +10,13 @@
 
 import React from "react/addons";
 import {TimeRange} from "@esnet/pond";
-import $ from "jquery";
 
 // http://stackoverflow.com/a/28857255
 function getElementOffset(element) {
-    var de = document.documentElement;
-    var box = element.getBoundingClientRect();
-    var top = box.top + window.pageYOffset - de.clientTop;
-    var left = box.left + window.pageXOffset - de.clientLeft;
+    const de = document.documentElement;
+    const box = element.getBoundingClientRect();
+    const top = box.top + window.pageYOffset - de.clientTop;
+    const left = box.left + window.pageXOffset - de.clientLeft;
     return {
         top: top,
         left: left

--- a/src/eventhandler.jsx
+++ b/src/eventhandler.jsx
@@ -12,6 +12,18 @@ import React from "react/addons";
 import {TimeRange} from "@esnet/pond";
 import $ from "jquery";
 
+// http://stackoverflow.com/a/28857255
+function getElementOffset(element) {
+    var de = document.documentElement;
+    var box = element.getBoundingClientRect();
+    var top = box.top + window.pageYOffset - de.clientTop;
+    var left = box.left + window.pageXOffset - de.clientLeft;
+    return {
+        top: top,
+        left: left
+    };
+}
+
 export default React.createClass({
 
     displayName: "EventHandler",
@@ -25,10 +37,12 @@ export default React.createClass({
         };
     },
 
+    // get the event mouse position relative to the event rect
     getOffsetMousePosition(e) {
-        const target = e.currentTarget;
-        const x = e.pageX - $(target).offset().left;
-        const y = e.pageY - $(target).offset().top;
+        const trackerRect = React.findDOMNode(this.refs.eventrect);
+        const offset = getElementOffset(trackerRect);
+        const x = e.pageX - offset.left;
+        const y = e.pageY - offset.top;
         return [Math.round(x), Math.round(y)];
     },
 
@@ -122,6 +136,7 @@ export default React.createClass({
 
     handleMouseOut(e) {
         e.preventDefault();
+
         if (this.props.onMouseOut) {
             this.props.onMouseOut();
         }
@@ -163,9 +178,8 @@ export default React.createClass({
                 this.props.onZoom(newTimeRange);
             }
         } else if (this.props.onMouseMove) {
-            const target = e.currentTarget;
-            const xx = e.pageX - $(target).offset().left;
-            const time = this.props.scale.invert(xx);
+            const trackerPosition = this.getOffsetMousePosition(e)[0];
+            const time = this.props.scale.invert(trackerPosition);
 
             // onMouseMove callback
             if (this.props.onMouseMove) {
@@ -188,6 +202,7 @@ export default React.createClass({
                onMouseOut={this.handleMouseOut}
                onMouseUp={this.handleMouseUp}>
                 <rect key="handler-hit-rect"
+                      ref="eventrect"
                       style={{opacity: 0.0, cursor: cursor}}
                       x={0} y={0}
                       width={this.props.width} height={this.props.height} />


### PR DESCRIPTION
Changes the AreaChart API. Fixes #25.

The `series` prop for an <AreaChart> now takes a single TimeSeries object (rather than array of arrays of TimeSeries). That single TimeSeries can have any number of columns of data, so the `columns` prop is now used to control what data columns map to what area chart, allowing them to stack up or down. It defaults to the "value" column. This is more consistent with other chart types.

Updates AreaChart examples and docs.

NOTE: BREAKING CHANGE