### PR TITLE
Improve brushing

### DIFF
--- a/examples/modules/app.jsx
+++ b/examples/modules/app.jsx
@@ -32,7 +32,7 @@ export default React.createClass({
                         <li><Link to="weather">Weather example</Link></li>
                         <li><Link to="ddos">DDoS example</Link></li>
                         <li><Link to="stacked">Continents</Link></li>
-                        <li><Link to="channels">Cycling example</Link></li>
+                        <li><Link to="channels">Brushing example</Link></li>
                     </ul>
 
                     <div className="sidebar-heading">API</div>

--- a/examples/modules/channels.css
+++ b/examples/modules/channels.css
@@ -1,0 +1,4 @@
+rect.extent {
+    fill: steelblue;
+    opacity: 0.4;
+}

--- a/examples/modules/channels.css
+++ b/examples/modules/channels.css
@@ -1,4 +1,4 @@
 rect.extent {
     fill: steelblue;
-    opacity: 0.4;
+    opacity: 0.25;
 }

--- a/examples/modules/channels.jsx
+++ b/examples/modules/channels.jsx
@@ -24,6 +24,9 @@ import YAxis from "../../src/yaxis";
 import LineChart from "../../src/linechart";
 import AreaChart from "../../src/areachart";
 import Resizable from "../../src/resizable";
+import Brush from "../../src/brush";
+
+import "./channels.css";
 
 // Data
 const data = require("../data/bike.json");
@@ -103,7 +106,7 @@ export default React.createClass({
     },
 
     handleTimeRangeChange(timerange) {
-        this.setState({timerange: timerange});
+        this.setState({timerange});
     },
 
     render() {
@@ -121,9 +124,13 @@ export default React.createClass({
                 <div className="row">
                     <div className="col-md-12">
                         <h3>Cycling example</h3>
-                        This example shows an activity (a 112 mile bike ride) as multiple channels of data.
-                        It demonstrates broken line capability with the line charts. Drag to pan, scrollwheel
-                        to zoom.
+                        This example shows an activity (a 112 mile bike ride) as two overlaid line charts.
+                        It demonstrates:
+                        <ul>
+                            <li>Broken line capability with the line charts</li>
+                            <li>Pan and zoom: Drag to pan, scrollwheel</li>
+                            <li>Brushing</li>
+                        </ul>
                     </div>
                 </div>
                 <div className="row">
@@ -165,14 +172,36 @@ export default React.createClass({
                                         width="80"
                                         type="linear" format="d"/>
                                 </ChartRow>
+                            </ChartContainer>
+                        </Resizable>
+                    </div>
+                </div>
+
+                <div className="row">
+                    <div className="col-md-12">
+                        <Resizable>
+                            <ChartContainer
+                                timeRange={altitude.range()}
+                                format="relative"
+                                trackerPosition={this.state.tracker}
+                                onTrackerChanged={this.handleTrackerChanged}>
                                 <ChartRow height="100" debug={false}>
+                                    <Brush
+                                        id="brush"
+                                        beginTime={this.state.timerange.begin()}
+                                        endTime={this.state.timerange.end()}
+                                        onTimeRangeChanged={this.handleTimeRangeChange} />
                                     <YAxis
                                         id="axis1"
                                         label="Altitude (ft)"
                                         min={0} max={altitude.max("altitude")}
-                                        width="60" type="linear" format="d"/>
+                                        width={60} type="linear" format="d"/>
                                     <Charts>
-                                        <AreaChart axis="axis1" columns={{up: ["altitude"], down: []}} series={altitude} />
+                                        <AreaChart
+                                            axis="axis1"
+                                            style={{up: ["#DDD"]}}
+                                            columns={{up: ["altitude"], down: []}}
+                                            series={altitude} />
                                     </Charts>
                                 </ChartRow>
                             </ChartContainer>

--- a/examples/modules/channels.jsx
+++ b/examples/modules/channels.jsx
@@ -83,11 +83,13 @@ const speed = new TimeSeries({
 });
 
 const paceStyle = {
-    color: "steelblue"
+    color: "steelblue",
+    width: 0.5
 };
 
 const hrStyle = {
-    color: "red"
+    color: "red",
+    width: 0.5
 };
 
 export default React.createClass({
@@ -97,7 +99,7 @@ export default React.createClass({
     getInitialState() {
         return {
             tracker: null,
-            timerange: new TimeRange([0, 120 * 60 * 1000])
+            timerange: new TimeRange([75 * 60 * 1000, 125 * 60 * 1000])
         };
     },
 
@@ -123,14 +125,15 @@ export default React.createClass({
             <div>
                 <div className="row">
                     <div className="col-md-12">
-                        <h3>Cycling example</h3>
-                        This example shows an activity (a 112 mile bike ride) as two overlaid line charts.
+                        <h3>Brushing example</h3>
+                        This example shows a 112 mile bike ride as two overlaid line charts: speed and heart rate.
                         It demonstrates:
                         <ul>
-                            <li>Broken line capability with the line charts</li>
-                            <li>Pan and zoom: Drag to pan, scrollwheel</li>
-                            <li>Brushing</li>
+                            <li>Broken lines for missing data</li>
+                            <li>Pan and zoom: Drag to pan, scrollwheel to zoom</li>
+                            <li>Brushing over an elevation chart: drag and resize the blue rectangle to pan and zoom</li>
                         </ul>
+                        <hr />
                     </div>
                 </div>
                 <div className="row">
@@ -153,6 +156,12 @@ export default React.createClass({
                                         min={0} max={35}
                                         width="60"
                                         type="linear" format=",.1f"/>
+                                    <YAxis
+                                        id="axis2"
+                                        label="Heart Rate (bpm)"
+                                        min={60} max={200}
+                                        width="60"
+                                        type="linear" format="d"/>
                                     <Charts>
                                         <LineChart
                                             axis="axis1"
@@ -165,12 +174,6 @@ export default React.createClass({
                                             style={hrStyle}
                                             breakLine={true}/>
                                     </Charts>
-                                    <YAxis
-                                        id="axis2"
-                                        label="Heart Rate (bpm)"
-                                        min={60} max={200}
-                                        width="80"
-                                        type="linear" format="d"/>
                                 </ChartRow>
                             </ChartContainer>
                         </Resizable>
@@ -183,19 +186,16 @@ export default React.createClass({
                             <ChartContainer
                                 timeRange={altitude.range()}
                                 format="relative"
-                                trackerPosition={this.state.tracker}
-                                onTrackerChanged={this.handleTrackerChanged}>
+                                trackerPosition={this.state.tracker} >
                                 <ChartRow height="100" debug={false}>
                                     <Brush
-                                        id="brush"
-                                        beginTime={this.state.timerange.begin()}
-                                        endTime={this.state.timerange.end()}
+                                        timeRange={this.state.timerange}
                                         onTimeRangeChanged={this.handleTimeRangeChange} />
                                     <YAxis
                                         id="axis1"
                                         label="Altitude (ft)"
                                         min={0} max={altitude.max("altitude")}
-                                        width={60} type="linear" format="d"/>
+                                        width={120} type="linear" format="d"/>
                                     <Charts>
                                         <AreaChart
                                             axis="axis1"

--- a/examples/modules/weather.jsx
+++ b/examples/modules/weather.jsx
@@ -146,7 +146,7 @@ export default React.createClass({
     getInitialState() {
         return {
             tracker: null
-        }
+        };
     },
 
     render() {

--- a/lib/brush.js
+++ b/lib/brush.js
@@ -28,6 +28,8 @@ var _d3 = require("d3");
 
 var _d32 = _interopRequireDefault(_d3);
 
+var _pondjs = require("pondjs");
+
 function scaleAsString(scale) {
     return scale.domain().toString() + "-" + scale.range().toString();
 }
@@ -36,46 +38,37 @@ exports["default"] = _react2["default"].createClass({
 
     displayName: "Brush",
 
-    getInitialState: function getInitialState() {
-        return {
-            d3brush: null
-        };
-    },
-
     handleBrushed: function handleBrushed(brush) {
         var extent = brush.extent();
-        if (this.props.onBrushed) {
-            this.props.onBrushed(brush, extent[0], extent[1]);
+        if (this.props.onTimeRangeChanged) {
+            this.props.onTimeRangeChanged(new _pondjs.TimeRange(extent[0], extent[1]));
         }
     },
 
     renderBrush: function renderBrush(timeScale, beginTime, endTime) {
         var _this = this;
 
-        var d3brush = this.state.d3brush;
-
-        if (!d3brush) {
-            d3brush = _d32["default"].svg.brush().x(timeScale).on("brush", function () {
-                _this.handleBrushed(d3brush);
+        if (!this.brush) {
+            this.brush = _d32["default"].svg.brush().x(timeScale).on("brush", function () {
+                _this.handleBrushed(_this.brush);
             });
-            this.setState({ d3brush: d3brush });
-            d3brush.extent([beginTime, endTime]);
+            this.brush.extent([beginTime, endTime]);
         } else {
-            var currentExtent = d3brush.extent();
-            var curBegin = currentExtent[0];
-            var curEnd = currentExtent[1];
+            var currentExtent = this.brush.extent();
+            var currentBegin = currentExtent[0];
+            var currentEnd = currentExtent[1];
 
             // This check is critical to break feedback cycles that
             // will cause the brush to get very confused.
-            if (curBegin.getTime() !== beginTime.getTime() || curEnd.getTime() !== endTime.getTime()) {
-                d3brush.extent([beginTime, endTime]);
+            if (currentBegin.getTime() !== beginTime.getTime() || currentEnd.getTime() !== endTime.getTime()) {
+                this.brush.extent([beginTime, endTime]);
             } else {
                 return;
             }
         }
         _d32["default"].select(_reactDom2["default"].findDOMNode(this)).selectAll("*").remove();
 
-        _d32["default"].select(_reactDom2["default"].findDOMNode(this)).append("g").attr("class", "x brush").call(d3brush).selectAll("rect").attr("y", -6).attr("height", this.props.height + 7);
+        _d32["default"].select(_reactDom2["default"].findDOMNode(this)).append("g").attr("class", "x brush").call(this.brush).selectAll("rect").attr("y", -6).attr("height", this.props.height + 7);
     },
 
     componentDidMount: function componentDidMount() {

--- a/lib/brush.js
+++ b/lib/brush.js
@@ -45,14 +45,14 @@ exports["default"] = _react2["default"].createClass({
         }
     },
 
-    renderBrush: function renderBrush(timeScale, beginTime, endTime) {
+    renderBrush: function renderBrush(timeScale, timeRange) {
         var _this = this;
 
         if (!this.brush) {
             this.brush = _d32["default"].svg.brush().x(timeScale).on("brush", function () {
                 _this.handleBrushed(_this.brush);
             });
-            this.brush.extent([beginTime, endTime]);
+            this.brush.extent([timeRange.begin(), timeRange.end()]);
         } else {
             var currentExtent = this.brush.extent();
             var currentBegin = currentExtent[0];
@@ -60,7 +60,7 @@ exports["default"] = _react2["default"].createClass({
 
             // This check is critical to break feedback cycles that
             // will cause the brush to get very confused.
-            if (currentBegin.getTime() !== beginTime.getTime() || currentEnd.getTime() !== endTime.getTime()) {
+            if (currentBegin.getTime() !== timeRange.begin().getTime() || currentEnd.getTime() !== timeRange.end().getTime()) {
                 this.brush.extent([beginTime, endTime]);
             } else {
                 return;
@@ -72,16 +72,14 @@ exports["default"] = _react2["default"].createClass({
     },
 
     componentDidMount: function componentDidMount() {
-        this.renderBrush(this.props.timeScale, this.props.beginTime, this.props.endTime);
+        this.renderBrush(this.props.timeScale, this.props.timeRange);
     },
 
     componentWillReceiveProps: function componentWillReceiveProps(nextProps) {
         var timeScale = nextProps.timeScale;
-        var beginTime = nextProps.beginTime;
-        var endTime = nextProps.endTime;
-
-        if (scaleAsString(this.props.timeScale) !== scaleAsString(timeScale) || this.props.beginTime.getTime() !== beginTime.getTime() || this.props.endTime.getTime() !== endTime.getTime()) {
-            this.renderBrush(timeScale, beginTime, endTime);
+        var timeRange = nextProps.timeRange;
+        if (scaleAsString(this.props.timeScale) !== scaleAsString(timeScale) || this.props.timeRange !== timeRange) {
+            this.renderBrush(timeScale, timeRange);
         }
     },
 

--- a/lib/brush.js
+++ b/lib/brush.js
@@ -58,10 +58,9 @@ exports["default"] = _react2["default"].createClass({
             var currentBegin = currentExtent[0];
             var currentEnd = currentExtent[1];
 
-            // This check is critical to break feedback cycles that
-            // will cause the brush to get very confused.
+            // Break feedback cycles
             if (currentBegin.getTime() !== timeRange.begin().getTime() || currentEnd.getTime() !== timeRange.end().getTime()) {
-                this.brush.extent([beginTime, endTime]);
+                this.brush.extent([timeRange.begin(), timeRange.end()]);
             } else {
                 return;
             }

--- a/lib/chartcontainer.js
+++ b/lib/chartcontainer.js
@@ -270,9 +270,11 @@ exports["default"] = _react2["default"].createClass({
                     var pos = countLeft - 1;
 
                     _react2["default"].Children.forEach(childRow.props.children, function (child) {
-                        if (child.type === _charts2["default"]) {
-                            align = "right";
-                            pos = 0;
+                        if (child.type === _charts2["default"] || child.type === _brush2["default"]) {
+                            if (child.type === _charts2["default"]) {
+                                align = "right";
+                                pos = 0;
+                            }
                         } else {
                             var width = Number(child.props.width) || 40;
                             if (align === "left") {
@@ -369,6 +371,7 @@ exports["default"] = _react2["default"].createClass({
         var timeAxis = _react2["default"].createElement(
             "g",
             { transform: "translate(" + leftWidth + "," + yPosition + ")" },
+            _react2["default"].createElement("path", { d: "M0,10V0H1299V10", style: { stroke: "#EDEDED", strokeWidth: 1, fill: "none" } }),
             _react2["default"].createElement(_timeaxis2["default"], { scale: timeScale, format: this.props.format })
         );
 

--- a/lib/chartrow.js
+++ b/lib/chartrow.js
@@ -191,7 +191,6 @@ exports["default"] = _react2["default"].createClass({
                 align = "right";
             } else {
                 var _id = child.props.id;
-
                 // Check to see if we think this 'axis' is actually an axis
                 if (child.type === _yaxis2["default"] || _underscore2["default"].has(child.props, "min") && _underscore2["default"].has(child.props, "max")) {
                     var yaxis = child;
@@ -209,13 +208,12 @@ exports["default"] = _react2["default"].createClass({
                     // Relate id to a d3 scale generated from the max, min
                     // and scaleType props
                     yAxisScaleMap[_id] = _this.createScale(yaxis, type, min, max, rangeBottom, rangeTop);
-                }
-
-                // Columns counts
-                if (align === "left") {
-                    leftAxisList.push(_id);
-                } else if (align === "right") {
-                    rightAxisList.push(_id);
+                    // Columns counts
+                    if (align === "left") {
+                        leftAxisList.push(_id);
+                    } else if (align === "right") {
+                        rightAxisList.push(_id);
+                    }
                 }
             }
         });

--- a/src/brush.jsx
+++ b/src/brush.jsx
@@ -28,14 +28,14 @@ export default React.createClass({
         }
     },
 
-    renderBrush(timeScale, beginTime, endTime) {
+    renderBrush(timeScale, timeRange) {
         if (!this.brush) {
             this.brush = d3.svg.brush()
                 .x(timeScale)
                 .on("brush", () => {
                     this.handleBrushed(this.brush);
                 });
-            this.brush.extent([beginTime, endTime]);
+            this.brush.extent([timeRange.begin(), timeRange.end()]);
         } else {
             const currentExtent = this.brush.extent();
             const currentBegin = currentExtent[0];
@@ -43,8 +43,8 @@ export default React.createClass({
 
             // This check is critical to break feedback cycles that
             // will cause the brush to get very confused.
-            if (currentBegin.getTime() !== beginTime.getTime() ||
-                currentEnd.getTime() !== endTime.getTime()) {
+            if (currentBegin.getTime() !== timeRange.begin().getTime() ||
+                currentEnd.getTime() !== timeRange.end().getTime()) {
                 this.brush.extent([beginTime, endTime]);
             } else {
                 return;
@@ -62,20 +62,15 @@ export default React.createClass({
     },
 
     componentDidMount() {
-        this.renderBrush(this.props.timeScale,
-                         this.props.beginTime,
-                         this.props.endTime);
+        this.renderBrush(this.props.timeScale, this.props.timeRange);
     },
 
     componentWillReceiveProps(nextProps) {
         const timeScale = nextProps.timeScale;
-        const beginTime = nextProps.beginTime;
-        const endTime = nextProps.endTime;
-
+        const timeRange = nextProps.timeRange;
         if (scaleAsString(this.props.timeScale) !== scaleAsString(timeScale) ||
-            this.props.beginTime.getTime() !== beginTime.getTime() ||
-            this.props.endTime.getTime() !== endTime.getTime() ) {
-            this.renderBrush(timeScale, beginTime, endTime);
+            this.props.timeRange !== timeRange) {
+            this.renderBrush(timeScale, timeRange);
         }
     },
 

--- a/src/brush.jsx
+++ b/src/brush.jsx
@@ -11,6 +11,7 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import d3 from "d3";
+import { TimeRange } from "pondjs";
 
 function scaleAsString(scale) {
     return `${scale.domain().toString()}-${scale.range().toString()}`;
@@ -20,40 +21,31 @@ export default React.createClass({
 
     displayName: "Brush",
 
-    getInitialState() {
-        return {
-            d3brush: null
-        };
-    },
-
     handleBrushed(brush) {
         const extent = brush.extent();
-        if (this.props.onBrushed) {
-            this.props.onBrushed(brush,extent[0],extent[1]);
+        if (this.props.onTimeRangeChanged) {
+            this.props.onTimeRangeChanged(new TimeRange(extent[0], extent[1]));
         }
     },
 
-    renderBrush(timeScale,beginTime,endTime) {
-        let d3brush = this.state.d3brush;
-
-        if (!d3brush) {
-            d3brush = d3.svg.brush()
+    renderBrush(timeScale, beginTime, endTime) {
+        if (!this.brush) {
+            this.brush = d3.svg.brush()
                 .x(timeScale)
                 .on("brush", () => {
-                    this.handleBrushed(d3brush);
+                    this.handleBrushed(this.brush);
                 });
-            this.setState({d3brush});
-            d3brush.extent([beginTime,endTime]);
+            this.brush.extent([beginTime, endTime]);
         } else {
-            const currentExtent = d3brush.extent();
-            const curBegin = currentExtent[0];
-            const curEnd = currentExtent[1];
+            const currentExtent = this.brush.extent();
+            const currentBegin = currentExtent[0];
+            const currentEnd = currentExtent[1];
 
             // This check is critical to break feedback cycles that
             // will cause the brush to get very confused.
-            if (curBegin.getTime() !== beginTime.getTime() ||
-                curEnd.getTime() !== endTime.getTime()) {
-                d3brush.extent([beginTime,endTime]);
+            if (currentBegin.getTime() !== beginTime.getTime() ||
+                currentEnd.getTime() !== endTime.getTime()) {
+                this.brush.extent([beginTime, endTime]);
             } else {
                 return;
             }
@@ -62,8 +54,8 @@ export default React.createClass({
 
         d3.select(ReactDOM.findDOMNode(this))
             .append("g")
-                .attr("class","x brush")
-                .call(d3brush)
+                .attr("class", "x brush")
+                .call(this.brush)
                 .selectAll("rect")
                 .attr("y", -6)
                 .attr("height", this.props.height + 7);

--- a/src/brush.jsx
+++ b/src/brush.jsx
@@ -41,11 +41,10 @@ export default React.createClass({
             const currentBegin = currentExtent[0];
             const currentEnd = currentExtent[1];
 
-            // This check is critical to break feedback cycles that
-            // will cause the brush to get very confused.
+            // Break feedback cycles
             if (currentBegin.getTime() !== timeRange.begin().getTime() ||
                 currentEnd.getTime() !== timeRange.end().getTime()) {
-                this.brush.extent([beginTime, endTime]);
+                this.brush.extent([timeRange.begin(), timeRange.end()]);
             } else {
                 return;
             }

--- a/src/chartcontainer.jsx
+++ b/src/chartcontainer.jsx
@@ -236,9 +236,11 @@ export default React.createClass({
                 let pos = countLeft - 1;
 
                 React.Children.forEach(childRow.props.children, child => {
-                    if (child.type === Charts) {
-                        align = "right";
-                        pos = 0;
+                    if (child.type === Charts || child.type === Brush) {
+                        if (child.type === Charts) {
+                            align = "right";
+                            pos = 0;
+                        }
                     } else {
                         const width = Number(child.props.width) || 40;
                         if (align === "left") {
@@ -334,6 +336,7 @@ export default React.createClass({
 
         const timeAxis = (
             <g transform={`translate(${leftWidth},${yPosition})`}>
+                <path d="M0,10V0H1299V10" style={{stroke: "#EDEDED", strokeWidth: 1, fill: "none"}}></path>
                 <TimeAxis scale={timeScale} format={this.props.format}/>
             </g>
         );

--- a/src/chartrow.jsx
+++ b/src/chartrow.jsx
@@ -175,7 +175,6 @@ export default React.createClass({
                 align = "right";
             } else {
                 const id = child.props.id;
-
                 // Check to see if we think this 'axis' is actually an axis
                 if (child.type === YAxis ||
                     (_.has(child.props, "min") &&
@@ -193,13 +192,12 @@ export default React.createClass({
                     // and scaleType props
                     yAxisScaleMap[id] = this.createScale(yaxis, type, min, max,
                                                          rangeBottom, rangeTop);
-                }
-
-                // Columns counts
-                if (align === "left") {
-                    leftAxisList.push(id);
-                } else if (align === "right") {
-                    rightAxisList.push(id);
+                    // Columns counts
+                    if (align === "left") {
+                        leftAxisList.push(id);
+                    } else if (align === "right") {
+                        rightAxisList.push(id);
+                    }
                 }
             }
         });


### PR DESCRIPTION
Adds a brushing example
Internal cleanup of the brushing code, with a couple of API changes:
  - specify current time range of the brush as a Pond `TimeRange` with the prop `timeRange`
  - subscribe to brush time range changes with the prop `onTimeRangeChange`. The callback will be supplied the TimeRange.
  - fixes for ChartRow and ChartContainer to properly interpret a brush within a row

### Example

![brushing](https://cloud.githubusercontent.com/assets/1288813/12927549/a58f6884-cf1d-11e5-90c9-da740cd563d4.gif)

### Code:
```
<ChartContainer
    timeRange={altitude.range()}
    format="relative"
    trackerPosition={this.state.tracker} >
    <ChartRow height="100" debug={false}>
        <Brush
            timeRange={this.state.timerange}
            onTimeRangeChanged={this.handleTimeRangeChange} />
        <YAxis
            id="axis1"
            label="Altitude (ft)"
            min={0} max={altitude.max("altitude")}
            width={120} type="linear" format="d"/>
        <Charts>
            <AreaChart
                axis="axis1"
                style={{up: ["#DDD"]}}
                columns={{up: ["altitude"], down: []}}
                series={altitude} />
        </Charts>
    </ChartRow>
</ChartContainer>
```
And styling for the brush rectangle:
```
rect.extent {
    fill: steelblue;
    opacity: 0.25;
}
```