### PR TITLE
Add hover text to bar charts.

### DIFF
--- a/examples/docs.json
+++ b/examples/docs.json
@@ -146,6 +146,21 @@
           "computed": false
         }
       },
+      "format": {
+        "type": {
+          "name": "union",
+          "value": [
+            {
+              "name": "func"
+            },
+            {
+              "name": "string"
+            }
+          ]
+        },
+        "required": false,
+        "description": "The format is used to format the hover text for the bar. It can be specified as a d3\nformat string (such as \".2f\") or a function. The function will be called with the value\nand should return a string."
+      },
       "size": {
         "type": {
           "name": "number"

--- a/examples/modules/barchart.jsx
+++ b/examples/modules/barchart.jsx
@@ -76,7 +76,8 @@ other chart types, the vertical scale is provided by referencing the \`<YAxis>\`
                     columns={["in"]}
                     series={octoberTrafficSeries}
                     selection={this.state.selection}
-                    onSelectionChange={this.handleSelectionChanged} />
+                    onSelectionChange={this.handleSelectionChanged}
+                    format={formatter} />
                 <Baseline
                     axis="traffic"
                     value={avgIn}
@@ -98,6 +99,15 @@ selected:
             selected: {fill: "#436D28"}
         }
     };
+
+The format prop provides the text that is displayed when bars are hovered over. This can either 
+be a d3 format string or a function. In this case we use a function to return the value:
+
+    // Return the value as the number of bytes e.g. "36 TB"
+    function formatter(value) {
+        const prefix = d3.formatPrefix(value);
+        return prefix.scale(value).toFixed() + " " + prefix.symbol + "B";
+    }
 
 As a side note, this chart can also be zoomed in and then panned with constraints. This is controlled
 using the \`<ChartContainer>\` props.
@@ -176,6 +186,11 @@ _.each(monthlyJSON, (router) => {
     }
 });
 
+function formatter(value) {
+    const prefix = d3.formatPrefix(value);
+    return `${prefix.scale(value).toFixed()} ${prefix.symbol}B`;
+}
+
 const monthlyAcceptedSeries = new TimeSeries({
     name: "Monthly Accepted",
     columns: ["time", "value"],
@@ -215,7 +230,6 @@ export default React.createClass({
     },
 
     render() {
-        const formatter = d3.format(".2s");
 
         const style = {
             in: {
@@ -283,7 +297,8 @@ export default React.createClass({
                                         <BarChart axis="traffic" style={leftStyle} columns={["in"]}
                                                   series={octoberTrafficSeries}
                                                   selection={this.state.selection}
-                                                  onSelectionChange={this.handleSelectionChanged}/>
+                                                  onSelectionChange={this.handleSelectionChanged}
+                                                  format={formatter} />
                                         <Baseline axis="traffic" value={avgIn} label="Avg" position="right"/>
                                     </Charts>
                                     <YAxis id="traffic-rate" label="Avg Traffic Rate In (bps)" classed="traffic-in"
@@ -328,8 +343,20 @@ export default React.createClass({
                                     <YAxis id="traffic-volume" label="Traffic (B)" classed="traffic-in"
                                            min={0} max={max} width="70" type="linear"/>
                                     <Charts>
-                                        <BarChart axis="traffic-volume" style={leftStyle} size={10} offset={5.5} columns={["in"]} series={octoberTrafficSeries} />
-                                        <BarChart axis="traffic-volume" style={rightStyle} size={10} offset={-5.5} columns={["out"]} series={octoberTrafficSeries} />
+                                        <BarChart
+                                            axis="traffic-volume"
+                                            style={leftStyle}
+                                            size={10}
+                                            offset={5.5}
+                                            columns={["in"]}
+                                            series={octoberTrafficSeries} />
+                                        <BarChart
+                                            axis="traffic-volume"
+                                            style={rightStyle}
+                                            size={10}
+                                            offset={-5.5}
+                                            columns={["out"]}
+                                            series={octoberTrafficSeries} />
                                     </Charts>
                                     <YAxis id="traffic-rate" label="Avg Traffic Rate (bps)" classed="traffic-in"
                                             min={0} max={ max / (24 * 60 * 60) * 8} width="70" type="linear"/>
@@ -365,7 +392,12 @@ export default React.createClass({
                                     <YAxis id="traffic-volume" label="Traffic (B)" classed="traffic-in"
                                            min={0} max={max} width="70" type="linear"/>
                                     <Charts>
-                                        <BarChart axis="traffic-volume" style={style} spacing={3} series={octoberTrafficSeries} />
+                                        <BarChart
+                                            axis="traffic-volume"
+                                            style={style}
+                                            spacing={3}
+                                            series={octoberTrafficSeries}
+                                            format={formatter}/>
                                     </Charts>
                                     <YAxis id="traffic-rate" label="Avg Traffic Rate (bps)" classed="traffic-in"
                                             min={0} max={ max / (24 * 60 * 60) * 8} width="70" type="linear"/>
@@ -400,7 +432,10 @@ export default React.createClass({
                                     <YAxis id="traffic" label="Traffic In (B)" classed="traffic-in"
                                            min={0} max={1500000000000000} width="70" type="linear"/>
                                     <Charts>
-                                        <BarChart axis="traffic" series={monthlyAcceptedSeries} />
+                                        <BarChart
+                                            axis="traffic"
+                                            series={monthlyAcceptedSeries}
+                                            format={formatter}/>
                                         <Baseline axis="traffic" value={monthlyAcceptedSeries.avg()} label="Avg "position="right"/>
                                     </Charts>
                                     <YAxis id="traffic-rate" label="Avg Traffic Rate In (bps)" classed="traffic-in"
@@ -411,7 +446,10 @@ export default React.createClass({
                                     <YAxis id="traffic" label="Traffic Out (B)" classed="traffic-out"
                                            min={0} max={1500000000000000} width="70" type="linear"/>
                                     <Charts>
-                                        <BarChart axis="traffic" series={monthlyDeliveredSeries} />
+                                        <BarChart
+                                            axis="traffic"
+                                            series={monthlyDeliveredSeries}
+                                            format={formatter}/>
                                         <Baseline axis="traffic" value={monthlyDeliveredSeries.avg()} label="Avg" position="right"/>
                                     </Charts>
                                     <YAxis id="traffic-rate" label="Avg Traffic Rate Out (bps)" classed="traffic-in"

--- a/examples/modules/barchart.jsx
+++ b/examples/modules/barchart.jsx
@@ -221,12 +221,14 @@ export default React.createClass({
             in: {
                 normal: {fill: "#619F3A"},
                 highlight: {fill: "rgb(113, 187, 67)"},
-                selected: {fill: "#436D28"}
+                selected: {fill: "#436D28"},
+                text: {fill: "#619F3A", stroke: "none"}
             },
             out: {
                 normal: {fill: "#E37E23"},
                 highlight: {fill: "rgb(255, 141, 39)"},
-                selected: {fill: "#A55D1C"}
+                selected: {fill: "#A55D1C"},
+                text: {fill: "#E37E23", stroke: "none"}
             }
         };
 
@@ -234,7 +236,8 @@ export default React.createClass({
             in: {
                 normal: {fill: "#619F3A"},
                 highlight: {fill: "rgb(113, 187, 67)"},
-                selected: {fill: "#436D28"}
+                selected: {fill: "#436D28"},
+                text: {fill: "#619F3A", stroke: "none"}
             }
         };
 
@@ -242,7 +245,8 @@ export default React.createClass({
             out: {
                 normal: {fill: "#E37E23"},
                 highlight: {fill: "rgb(255, 141, 39)"},
-                selected: {fill: "#B3621A"}
+                selected: {fill: "#B3621A"},
+                text: {fill: "#E37E23", stroke: "none"}
             }
         };
 

--- a/lib/barchart.js
+++ b/lib/barchart.js
@@ -22,6 +22,10 @@ var _react = require("react");
 
 var _react2 = _interopRequireDefault(_react);
 
+var _d3 = require("d3");
+
+var _d32 = _interopRequireDefault(_d3);
+
 var _pondjs = require("pondjs");
 
 /**
@@ -140,6 +144,8 @@ exports["default"] = _react2["default"].createClass({
         var columns = this.props.columns || series._columns;
 
         var rects = [];
+        var hover = [];
+
         var _iteratorNormalCompletion = true;
         var _didIteratorError = false;
         var _iteratorError = undefined;
@@ -193,6 +199,7 @@ exports["default"] = _react2["default"].createClass({
                         var y = ypos - height;
 
                         var barStyle = undefined;
+                        var hoverText = null;
                         if (key === _this.props.selection) {
                             if (_this.props.style && _this.props.style[column].selected) {
                                 barStyle = _this.props.style[column].selected;
@@ -211,19 +218,44 @@ exports["default"] = _react2["default"].createClass({
                             barStyle = { fill: "steelblue" };
                         }
 
-                        rects.push(_react2["default"].createElement("rect", { key: key,
-                            x: x, y: y, width: width, height: height,
+                        // Hover text
+                        if (key === _this.state.hover || key === _this.props.selection) {
+                            var formatter = _this.props.textFormat || _d32["default"].format(".2s");
+                            var barTextStyle = _this.props.style[column].text || { stroke: "steelblue" };
+                            hoverText = _react2["default"].createElement(
+                                "text",
+                                {
+                                    key: key,
+                                    style: barTextStyle,
+                                    x: x + width / 2,
+                                    y: y - 2,
+                                    fontFamily: "Verdana",
+                                    textAnchor: "middle",
+                                    fontSize: "12" },
+                                formatter(value)
+                            );
+                        }
+
+                        if (hoverText) {
+                            hover.push(hoverText);
+                        }
+                        rects.push(_react2["default"].createElement("rect", {
+                            key: key,
+                            x: x,
+                            y: y,
+                            width: width,
+                            height: height,
                             pointerEvents: "none",
                             style: barStyle,
                             clipPath: _this.props.clipPathURL,
                             onClick: function (e) {
-                                _this.handleClick(e, key, value, series, column, index);
+                                return _this.handleClick(e, key, value, series, column, index);
                             },
                             onMouseLeave: function () {
-                                _this.setState({ hover: null });
+                                return _this.setState({ hover: null });
                             },
                             onMouseMove: function (e) {
-                                _this.handleMouseMove(e, key);
+                                return _this.handleMouseMove(e, key);
                             } }));
 
                         ypos -= height;
@@ -262,7 +294,12 @@ exports["default"] = _react2["default"].createClass({
             }
         }
 
-        return rects;
+        return _react2["default"].createElement(
+            "g",
+            null,
+            rects,
+            hover
+        );
     },
 
     render: function render() {

--- a/lib/barchart.js
+++ b/lib/barchart.js
@@ -26,6 +26,10 @@ var _d3 = require("d3");
 
 var _d32 = _interopRequireDefault(_d3);
 
+var _underscore = require("underscore");
+
+var _underscore2 = _interopRequireDefault(_underscore);
+
 var _pondjs = require("pondjs");
 
 /**
@@ -86,6 +90,13 @@ exports["default"] = _react2["default"].createClass({
          * ```
          */
         style: _react2["default"].PropTypes.object,
+
+        /**
+         * The format is used to format the hover text for the bar. It can be specified as a d3
+         * format string (such as ".2f") or a function. The function will be called with the value
+         * and should return a string.
+         */
+        format: _react2["default"].PropTypes.oneOfType([_react2["default"].PropTypes.func, _react2["default"].PropTypes.string]),
 
         /**
          * If size is specified, then the bar will be this number of pixels wide. This
@@ -219,8 +230,15 @@ exports["default"] = _react2["default"].createClass({
                         }
 
                         // Hover text
+                        var text = "" + value;
                         if (key === _this.state.hover || key === _this.props.selection) {
-                            var formatter = _this.props.textFormat || _d32["default"].format(".2s");
+                            if (_this.props.format && _underscore2["default"].isString(_this.props.format)) {
+                                var formatter = _d32["default"].format(_this.props.format);
+                                text = formatter(value);
+                            } else if (_underscore2["default"].isFunction(_this.props.format)) {
+                                text = _this.props.format(value);
+                            }
+
                             var barTextStyle = _this.props.style[column].text || { stroke: "steelblue" };
                             hoverText = _react2["default"].createElement(
                                 "text",
@@ -232,7 +250,7 @@ exports["default"] = _react2["default"].createClass({
                                     fontFamily: "Verdana",
                                     textAnchor: "middle",
                                     fontSize: "12" },
-                                formatter(value)
+                                text
                             );
                         }
 

--- a/src/barchart.jsx
+++ b/src/barchart.jsx
@@ -10,6 +10,8 @@
 
 import React from "react";
 import d3 from "d3";
+import _ from "underscore";
+
 import { TimeSeries } from "pondjs";
 
 /**
@@ -73,6 +75,16 @@ export default React.createClass({
          */
         style: React.PropTypes.object,
         
+        /**
+         * The format is used to format the hover text for the bar. It can be specified as a d3
+         * format string (such as ".2f") or a function. The function will be called with the value
+         * and should return a string.
+         */
+        format: React.PropTypes.oneOfType([
+            React.PropTypes.func,
+            React.PropTypes.string
+        ]),
+
         /**
          * If size is specified, then the bar will be this number of pixels wide. This
          * prop takes priority of "spacing".
@@ -193,8 +205,15 @@ export default React.createClass({
                 }
 
                 // Hover text
-                if (key === this.state.hover || key === this.props.selection) {
-                    const formatter = this.props.textFormat || d3.format(".2s");
+                let text = `${value}`;
+                if (this.props.format && (key === this.state.hover || key === this.props.selection)) {
+                    if (this.props.format && _.isString(this.props.format)) {
+                        const formatter = d3.format(this.props.format);
+                        text = formatter(value);
+                    } else if (_.isFunction(this.props.format)) {
+                        text = this.props.format(value);
+                    }
+                    
                     const barTextStyle = this.props.style[column].text || {stroke: "steelblue"};
                     hoverText = (
                         <text
@@ -205,7 +224,7 @@ export default React.createClass({
                             fontFamily="Verdana"
                             textAnchor="middle"
                             fontSize="12">
-                            {formatter(value)}
+                            {text}
                         </text>
                     );
                 }


### PR DESCRIPTION
Adds hover text to bar charts. Fixes #16.

![barchart](https://cloud.githubusercontent.com/assets/1288813/12969070/07dc95da-d030-11e5-89ba-bf6dd06fc677.gif)

I can imagine other options, but this moves the ball forward.