### PR TITLE
Replace d3 brush

### DIFF
--- a/examples/docs.json
+++ b/examples/docs.json
@@ -395,38 +395,156 @@
     }
   },
   "src/brush.jsx": {
-    "description": "",
+    "description": "Renders a brush with the range defined in the prop `timeRange`.",
     "displayName": "Brush",
     "methods": [
       {
-        "name": "handleBrushed",
+        "name": "viewport",
+        "docblock": null,
+        "modifiers": [],
+        "params": [],
+        "returns": null
+      },
+      {
+        "name": "handleBrushMouseDown",
         "docblock": null,
         "modifiers": [],
         "params": [
           {
-            "name": "brush",
+            "name": "e",
             "type": null
           }
         ],
         "returns": null
       },
       {
-        "name": "renderBrush",
+        "name": "handleOverlayMouseDown",
         "docblock": null,
         "modifiers": [],
         "params": [
           {
-            "name": "timeScale",
-            "type": null
-          },
-          {
-            "name": "timeRange",
+            "name": "e",
             "type": null
           }
         ],
         "returns": null
+      },
+      {
+        "name": "handleHandleMouseDown",
+        "docblock": null,
+        "modifiers": [],
+        "params": [
+          {
+            "name": "e",
+            "type": null
+          },
+          {
+            "name": "handle",
+            "type": null
+          }
+        ],
+        "returns": null
+      },
+      {
+        "name": "handleMouseUp",
+        "docblock": null,
+        "modifiers": [],
+        "params": [
+          {
+            "name": "e",
+            "type": null
+          }
+        ],
+        "returns": null
+      },
+      {
+        "name": "handleClick",
+        "docblock": "Handles clearing the TimeRange if the user clicks on the overlay (but\ndoesn't drag to create a new brush). This will send a null as the\nnew TimeRange. The user of this code can react to that however they\nsee fit, but the most logical response is to reset the timerange to\nsome initial value. This behavior is optional.",
+        "modifiers": [],
+        "params": [],
+        "returns": null,
+        "description": "Handles clearing the TimeRange if the user clicks on the overlay (but\ndoesn't drag to create a new brush). This will send a null as the\nnew TimeRange. The user of this code can react to that however they\nsee fit, but the most logical response is to reset the timerange to\nsome initial value. This behavior is optional."
+      },
+      {
+        "name": "handleMouseMove",
+        "docblock": null,
+        "modifiers": [],
+        "params": [
+          {
+            "name": "e",
+            "type": null
+          }
+        ],
+        "returns": null
+      },
+      {
+        "name": "renderOverlay",
+        "docblock": null,
+        "modifiers": [],
+        "params": [],
+        "returns": null
+      },
+      {
+        "name": "renderBrush",
+        "docblock": null,
+        "modifiers": [],
+        "params": [],
+        "returns": null
+      },
+      {
+        "name": "renderHandles",
+        "docblock": null,
+        "modifiers": [],
+        "params": [],
+        "returns": null
       }
-    ]
+    ],
+    "props": {
+      "timeRange": {
+        "type": {
+          "name": "instanceOf",
+          "value": "TimeRange"
+        },
+        "required": false,
+        "description": "The timerange for the brush. Typically you would maintain this\nas state on the surrounding page, since it would likely control\nanother page element, such as the range of the main chart. See\nalso `onTimeRangeChanged()` for receiving notification of the\nbrush range being changed by the user.\n\nTakes a Pond TimeRange object."
+      },
+      "style": {
+        "type": {
+          "name": "object"
+        },
+        "required": false,
+        "description": "The brush is rendered as an SVG rect. You can specify the style\nof this rect using this prop."
+      },
+      "handleSize": {
+        "type": {
+          "name": "number"
+        },
+        "required": false,
+        "description": "The size of the invisible side handles. Defaults to 6 pixels.",
+        "defaultValue": {
+          "value": "6",
+          "computed": false
+        }
+      },
+      "allowSelectionClear": {
+        "type": {
+          "name": "bool"
+        },
+        "required": false,
+        "description": "",
+        "defaultValue": {
+          "value": "false",
+          "computed": false
+        }
+      },
+      "onTimeRangeChanged": {
+        "type": {
+          "name": "func"
+        },
+        "required": false,
+        "description": "A callback which will be called if the brush range is changed by\nthe user. It is called with a Pond TimeRange object. Note that if\n`allowSelectionClear` is set to true, then this can also be called\nwhen the user performs a simple click outside the brush area. In\nthis case it will be called with null as the TimeRange. You can\nuse this to reset the selection, perhaps to some initial range."
+      }
+    }
   },
   "src/chartcontainer.jsx": {
     "description": "The `<ChartContainer>` is the outer most element of a chart and is responsible for generating and arranging its sub-elements. Specifically, it is a container for one or more `<ChartRows>` (each of which contains charts, axes etc) and in addition it manages the overall time range of the chart and so also is responsible for the time axis, which is always shared by all the rows.\n\n![ChartContainer](https://raw.githubusercontent.com/esnet/react-timeseries-charts/master/docs/chartcontainer.png \"ChartContainer\")\n\nHere is an example:\n\n```xml\n<ChartContainer timeRange={audSeries.timerange()} width=\"800\">\n    <ChartRow>\n        ...\n    </ChartRow>\n    <ChartRow>\n        ...\n    </ChartRow>\n</ChartContainer>\n```",

--- a/examples/modules/barchart.jsx
+++ b/examples/modules/barchart.jsx
@@ -12,7 +12,6 @@
 
 import React from "react";
 import _ from "underscore";
-import d3 from "d3";
 import Markdown from "react-markdown";
 import Highlighter from "./highlighter";
 import APIDocs from "./docs";

--- a/examples/modules/channels.jsx
+++ b/examples/modules/channels.jsx
@@ -130,10 +130,12 @@ export default React.createClass({
     mixins: [Highlighter],
 
     getInitialState() {
+        const initialRange = new TimeRange([75 * 60 * 1000, 125 * 60 * 1000]);
         return {
             mode: "channels",
             tracker: null,
-            timerange: new TimeRange([75 * 60 * 1000, 125 * 60 * 1000])
+            timerange: initialRange,
+            brushrange: initialRange
         };
     },
 
@@ -141,8 +143,13 @@ export default React.createClass({
         this.setState({tracker: t});
     },
 
+    // Handles when the brush changes the timerange
     handleTimeRangeChange(timerange) {
-        this.setState({timerange});
+        if (timerange) {
+            this.setState({timerange, brushrange: timerange});
+        } else {
+            this.setState({timerange: altitude.range(), brushrange: null});
+        }
     },
 
     renderDescription() {
@@ -375,7 +382,8 @@ export default React.createClass({
                 trackerPosition={this.state.tracker}>
                 <ChartRow height="100" debug={false}>
                     <Brush
-                        timeRange={this.state.timerange}
+                        timeRange={this.state.brushrange}
+                        allowSelectionClear={true}
                         onTimeRangeChanged={this.handleTimeRangeChange} />
                     <YAxis
                         id="axis1"

--- a/examples/modules/linechart.jsx
+++ b/examples/modules/linechart.jsx
@@ -11,7 +11,8 @@
 /* eslint max-len:0 */
 
 import React from "react";
-import d3 from "d3";
+import { format } from "d3-format";
+import { timeFormat } from "d3-time-format";
 import Highlighter from "./highlighter";
 import APIDocs from "./docs";
 
@@ -81,8 +82,8 @@ export default React.createClass({
     },
 
     render() {
-        const f = d3.format("$,.2f");
-        const df = d3.time.format("%b %d %Y %X");
+        const f = format("$,.2f");
+        const df = timeFormat("%b %d %Y %X");
 
         const timeStyle = {
             fontSize: "1.2rem",

--- a/examples/modules/weather.jsx
+++ b/examples/modules/weather.jsx
@@ -138,19 +138,19 @@ const scheme = {
 const lineStyles = {
     temp: {
         stroke: scheme.temp,
-        "stroke-width": 2
+        strokeWidth: 2
     },
     pressure: {
         stroke: scheme.pressure,
-        "stroke-width": 2
+        strokeWidth: 2
     },
     wind: {
         stroke: scheme.wind,
-        "stroke-width": 2
+        strokeWidth: 2
     },
     rainAccum: {
         stroke: scheme.rainAccum,
-        "stroke-width": 1
+        strokeWidth: 1
     }
 };
 

--- a/lib/brush.js
+++ b/lib/brush.js
@@ -4,85 +4,402 @@ Object.defineProperty(exports, "__esModule", {
     value: true
 });
 
+var _slicedToArray = function () { function sliceIterator(arr, i) { var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"]) _i["return"](); } finally { if (_d) throw _e; } } return _arr; } return function (arr, i) { if (Array.isArray(arr)) { return arr; } else if (Symbol.iterator in Object(arr)) { return sliceIterator(arr, i); } else { throw new TypeError("Invalid attempt to destructure non-iterable instance"); } }; }();
+
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; /**
+                                                                                                                                                                                                                                                                   *  Copyright (c) 2016, The Regents of the University of California,
+                                                                                                                                                                                                                                                                   *  through Lawrence Berkeley National Laboratory (subject to receipt
+                                                                                                                                                                                                                                                                   *  of any required approvals from the U.S. Dept. of Energy).
+                                                                                                                                                                                                                                                                   *  All rights reserved.
+                                                                                                                                                                                                                                                                   *
+                                                                                                                                                                                                                                                                   *  This source code is licensed under the BSD-style license found in the
+                                                                                                                                                                                                                                                                   *  LICENSE file in the root directory of this source tree.
+                                                                                                                                                                                                                                                                   */
+
 var _react = require("react");
 
 var _react2 = _interopRequireDefault(_react);
 
-var _reactDom = require("react-dom");
+var _merge = require("merge");
 
-var _reactDom2 = _interopRequireDefault(_reactDom);
-
-var _d = require("d3");
-
-var _d2 = _interopRequireDefault(_d);
+var _merge2 = _interopRequireDefault(_merge);
 
 var _pondjs = require("pondjs");
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
+// http://stackoverflow.com/a/28857255
+function getElementOffset(element) {
+    var de = document.documentElement;
+    var box = element.getBoundingClientRect();
+    var top = box.top + window.pageYOffset - de.clientTop;
+    var left = box.left + window.pageXOffset - de.clientLeft;
+    return { top: top, left: left };
+}
+
 /**
- *  Copyright (c) 2015, The Regents of the University of California,
- *  through Lawrence Berkeley National Laboratory (subject to receipt
- *  of any required approvals from the U.S. Dept. of Energy).
- *  All rights reserved.
- *
- *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree.
+ * Renders a brush with the range defined in the prop `timeRange`.
  */
-
-function scaleAsString(scale) {
-    return scale.domain().toString() + "-" + scale.range().toString();
-} // TODO: use d3-brush when it becomes available
-
-
 exports.default = _react2.default.createClass({
 
     displayName: "Brush",
 
-    handleBrushed: function handleBrushed(brush) {
-        var extent = brush.extent();
-        if (this.props.onTimeRangeChanged) {
-            this.props.onTimeRangeChanged(new _pondjs.TimeRange(extent[0], extent[1]));
+    propTypes: {
+
+        /**
+         * The timerange for the brush. Typically you would maintain this
+         * as state on the surrounding page, since it would likely control
+         * another page element, such as the range of the main chart. See
+         * also `onTimeRangeChanged()` for receiving notification of the
+         * brush range being changed by the user.
+         *
+         * Takes a Pond TimeRange object.
+         */
+        timeRange: _react2.default.PropTypes.instanceOf(_pondjs.TimeRange),
+
+        /**
+         * The brush is rendered as an SVG rect. You can specify the style
+         * of this rect using this prop.
+         */
+        style: _react2.default.PropTypes.object,
+
+        /**
+         * The size of the invisible side handles. Defaults to 6 pixels.
+         */
+        handleSize: _react2.default.PropTypes.number,
+
+        allowSelectionClear: _react2.default.PropTypes.bool,
+
+        /**
+         * A callback which will be called if the brush range is changed by
+         * the user. It is called with a Pond TimeRange object. Note that if
+         * `allowSelectionClear` is set to true, then this can also be called
+         * when the user performs a simple click outside the brush area. In
+         * this case it will be called with null as the TimeRange. You can
+         * use this to reset the selection, perhaps to some initial range.
+         */
+        onTimeRangeChanged: _react2.default.PropTypes.func
+    },
+
+    getDefaultProps: function getDefaultProps() {
+        return {
+            handleSize: 6,
+            allowSelectionClear: false
+        };
+    },
+    getInitialState: function getInitialState() {
+        return {
+            isBrushing: false
+        };
+    },
+    viewport: function viewport() {
+        var _props = this.props;
+        var width = _props.width;
+        var timeScale = _props.timeScale;
+
+        var viewBeginTime = timeScale.invert(0);
+        var viewEndTime = timeScale.invert(width);
+        return new _pondjs.TimeRange(viewBeginTime, viewEndTime);
+    },
+    handleBrushMouseDown: function handleBrushMouseDown(e) {
+        e.preventDefault();
+
+        var x = e.pageX;
+        var y = e.pageY;
+
+        var xy0 = [Math.round(x), Math.round(y)];
+        var begin = +this.props.timeRange.begin();
+        var end = +this.props.timeRange.end();
+
+        this.setState({
+            isBrushing: true,
+            brushingInitializationSite: "brush",
+            initialBrushBeginTime: begin,
+            initialBrushEndTime: end,
+            initialBrushXYPosition: xy0
+        });
+    },
+    handleOverlayMouseDown: function handleOverlayMouseDown(e) {
+        e.preventDefault();
+
+        var offset = getElementOffset(this.refs.overlay);
+        var x = e.pageX - offset.left;
+        var t = this.props.timeScale.invert(x).getTime();
+        this.setState({
+            isBrushing: true,
+            brushingInitializationSite: "overlay",
+            initialBrushBeginTime: t,
+            initialBrushEndTime: t,
+            initialBrushXYPosition: null
+        });
+    },
+    handleHandleMouseDown: function handleHandleMouseDown(e, handle) {
+        e.preventDefault();
+
+        var x = e.pageX;
+        var y = e.pageY;
+
+        var xy0 = [Math.round(x), Math.round(y)];
+        var begin = this.props.timeRange.begin().getTime();
+        var end = this.props.timeRange.end().getTime();
+
+        document.addEventListener("mouseover", this.handleMouseMove);
+        document.addEventListener("mouseup", this.handleMouseUp);
+
+        this.setState({
+            isBrushing: true,
+            brushingInitializationSite: "handle-" + handle,
+            initialBrushBeginTime: begin,
+            initialBrushEndTime: end,
+            initialBrushXYPosition: xy0
+        });
+    },
+    handleMouseUp: function handleMouseUp(e) {
+        e.preventDefault();
+
+        document.removeEventListener("mouseover", this.handleMouseMove);
+        document.removeEventListener("mouseup", this.handleMouseUp);
+
+        this.setState({
+            isBrushing: false,
+            brushingInitializationSite: null,
+            initialBrushBeginTime: null,
+            initialBrushEndTime: null,
+            initialBrushXYPosition: null
+        });
+    },
+
+
+    /**
+     * Handles clearing the TimeRange if the user clicks on the overlay (but
+     * doesn't drag to create a new brush). This will send a null as the
+     * new TimeRange. The user of this code can react to that however they
+     * see fit, but the most logical response is to reset the timerange to
+     * some initial value. This behavior is optional.
+     */
+    handleClick: function handleClick() {
+        if (this.props.allowSelectionClear && this.props.onTimeRangeChanged) {
+            this.props.onTimeRangeChanged(null);
         }
     },
-    renderBrush: function renderBrush(timeScale, timeRange) {
-        var _this = this;
+    handleMouseMove: function handleMouseMove(e) {
+        e.preventDefault();
 
-        if (!this.brush) {
-            this.brush = _d2.default.svg.brush().x(timeScale).on("brush", function () {
-                _this.handleBrushed(_this.brush);
-            });
-            this.brush.extent([timeRange.begin(), timeRange.end()]);
-        } else {
-            var currentExtent = this.brush.extent();
-            var currentBegin = currentExtent[0];
-            var currentEnd = currentExtent[1];
+        var x = e.pageX;
+        var y = e.pageY;
+        var xy = [Math.round(x), Math.round(y)];
+        var viewport = this.viewport();
 
-            // Break feedback cycles
-            if (currentBegin.getTime() !== timeRange.begin().getTime() || currentEnd.getTime() !== timeRange.end().getTime()) {
-                this.brush.extent([timeRange.begin(), timeRange.end()]);
+        if (this.state.isBrushing) {
+            var newBegin = void 0,
+                newEnd = void 0;
+
+            var tb = this.state.initialBrushBeginTime;
+            var te = this.state.initialBrushEndTime;
+
+            if (this.state.brushingInitializationSite === "overlay") {
+                var offset = getElementOffset(this.refs.overlay);
+                var xx = e.pageX - offset.left;
+                var t = this.props.timeScale.invert(xx).getTime();
+                if (t < tb) {
+                    newBegin = t < viewport.begin().getTime() ? viewport.begin() : t;
+                    newEnd = tb > viewport.end().getTime() ? viewport.end() : tb;
+                } else {
+                    newBegin = tb < viewport.begin().getTime() ? viewport.begin() : tb;
+                    newEnd = t > viewport.end().getTime() ? viewport.end() : t;
+                }
             } else {
-                return;
+                var xy0 = this.state.initialBrushXYPosition;
+                var timeOffset = this.props.timeScale.invert(xy0[0]).getTime() - this.props.timeScale.invert(xy[0]).getTime();
+
+                // Constrain
+                if (tb - timeOffset < viewport.begin()) {
+                    timeOffset = tb - viewport.begin().getTime();
+                }
+                if (te - timeOffset > viewport.end()) {
+                    timeOffset = te - viewport.end().getTime();
+                }
+
+                newBegin = this.state.brushingInitializationSite === "brush" || this.state.brushingInitializationSite === "handle-left" ? parseInt(tb - timeOffset, 10) : tb;
+                newEnd = this.state.brushingInitializationSite === "brush" || this.state.brushingInitializationSite === "handle-right" ? parseInt(te - timeOffset, 10) : te;
+
+                // Swap if needed
+                if (newBegin > newEnd) {
+                    ;
+                    var _ref = [newEnd, newBegin];
+                    newBegin = _ref[0];
+                    newEnd = _ref[1];
+                }
+            }
+
+            if (this.props.onTimeRangeChanged) {
+                this.props.onTimeRangeChanged(new _pondjs.TimeRange(newBegin, newEnd));
             }
         }
-        _d2.default.select(_reactDom2.default.findDOMNode(this)).selectAll("*").remove();
+    },
+    renderOverlay: function renderOverlay() {
+        var _props2 = this.props;
+        var width = _props2.width;
+        var height = _props2.height;
 
-        _d2.default.select(_reactDom2.default.findDOMNode(this)).append("g").attr("class", "x brush").call(this.brush).selectAll("rect").attr("y", -6).attr("height", this.props.height + 7);
+
+        var cursor = void 0;
+        switch (this.state.brushingInitializationSite) {
+            case "handle-right":
+            case "handle-left":
+                cursor = "ew-resize";
+                break;
+            case "brush":
+                cursor = "move";
+                break;
+            default:
+                cursor = "crosshair";
+        }
+
+        var overlayStyle = {
+            fill: "white",
+            opacity: 0,
+            cursor: cursor
+        };
+        return _react2.default.createElement("rect", {
+            ref: "overlay",
+            x: 0, y: 0,
+            width: width, height: height,
+            style: overlayStyle,
+            onMouseDown: this.handleOverlayMouseDown,
+            onMouseUp: this.handleMouseUp,
+            onClick: this.handleClick,
+            clipPath: this.props.clipPathURL });
     },
-    componentDidMount: function componentDidMount() {
-        this.renderBrush(this.props.timeScale, this.props.timeRange);
-    },
-    componentWillReceiveProps: function componentWillReceiveProps(nextProps) {
-        var timeScale = nextProps.timeScale;
-        var timeRange = nextProps.timeRange;
-        if (scaleAsString(this.props.timeScale) !== scaleAsString(timeScale) || this.props.timeRange !== timeRange) {
-            this.renderBrush(timeScale, timeRange);
+    renderBrush: function renderBrush() {
+        var _props3 = this.props;
+        var timeRange = _props3.timeRange;
+        var timeScale = _props3.timeScale;
+        var height = _props3.height;
+        var style = _props3.style;
+
+
+        if (!timeRange) {
+            return _react2.default.createElement("g", null);
+        }
+
+        var cursor = void 0;
+        switch (this.state.brushingInitializationSite) {
+            case "handle-right":
+            case "handle-left":
+                cursor = "ew-resize";
+                break;
+            case "overlay":
+                cursor = "crosshair";
+                break;
+            default:
+                cursor = "move";
+        }
+
+        // Style of the brush area
+        var brushDefaultStyle = {
+            fill: "#777",
+            fillOpacity: 0.3,
+            stroke: "#fff",
+            shapeRendering: "crispEdges",
+            cursor: cursor
+        };
+        var brushStyle = (0, _merge2.default)(true, brushDefaultStyle, style);
+
+        if (!this.viewport().disjoint(timeRange)) {
+            var range = timeRange.intersection(this.viewport());
+            var begin = range.begin();
+            var end = range.end();
+            var x = timeScale(begin);
+            var y = 0;
+
+            var endPos = timeScale(end);
+            var width = endPos - x;
+            if (width < 1) {
+                width = 1;
+            }
+
+            var bounds = { x: x, y: y, width: width, height: height };
+
+            return _react2.default.createElement("rect", _extends({}, bounds, {
+                style: brushStyle,
+                pointerEvents: "all",
+                onMouseDown: this.handleBrushMouseDown,
+                onMouseUp: this.handleMouseUp,
+                clipPath: this.props.clipPathURL }));
         }
     },
-    shouldComponentUpdate: function shouldComponentUpdate() {
-        return false;
+    renderHandles: function renderHandles() {
+        var _this = this;
+
+        var _props4 = this.props;
+        var timeRange = _props4.timeRange;
+        var timeScale = _props4.timeScale;
+        var height = _props4.height;
+
+
+        if (!timeRange) {
+            return _react2.default.createElement("g", null);
+        }
+
+        // Style of the handles
+        var handleStyle = {
+            fill: "white",
+            opacity: 0,
+            cursor: "ew-resize"
+        };
+
+        if (!this.viewport().disjoint(timeRange)) {
+            var range = timeRange.intersection(this.viewport());
+
+            var _range$toJSON = range.toJSON();
+
+            var _range$toJSON2 = _slicedToArray(_range$toJSON, 2);
+
+            var begin = _range$toJSON2[0];
+            var end = _range$toJSON2[1];
+            var x = timeScale(begin);
+            var y = 0;
+
+            var endPos = timeScale(end);
+
+            var width = endPos - x;
+            if (width < 1) {
+                width = 1;
+            }
+
+            var handleSize = this.props.handleSize;
+
+            var leftHandleBounds = { x: x - 1, y: y, width: handleSize, height: height };
+            var rightHandleBounds = { x: x + width - handleSize, y: y, width: handleSize + 1, height: height };
+
+            return _react2.default.createElement(
+                "g",
+                null,
+                _react2.default.createElement("rect", _extends({}, leftHandleBounds, {
+                    style: handleStyle,
+                    pointerEvents: "all",
+                    onMouseDown: function onMouseDown(e) {
+                        return _this.handleHandleMouseDown(e, "left");
+                    },
+                    onMouseUp: this.handleMouseUp })),
+                _react2.default.createElement("rect", _extends({}, rightHandleBounds, {
+                    style: handleStyle,
+                    pointerEvents: "all",
+                    onMouseDown: function onMouseDown(e) {
+                        return _this.handleHandleMouseDown(e, "right");
+                    },
+                    onMouseUp: this.handleMouseUp }))
+            );
+        }
     },
     render: function render() {
-        return _react2.default.createElement("g", null);
+        return _react2.default.createElement(
+            "g",
+            { onMouseMove: this.handleMouseMove },
+            this.renderOverlay(),
+            this.renderBrush(),
+            this.renderHandles()
+        );
     }
 });

--- a/lib/chartrow.js
+++ b/lib/chartrow.js
@@ -447,6 +447,7 @@ exports.default = _react2.default.createClass({
                     key: "brush-" + keyCount,
                     width: chartWidth,
                     height: innerHeight,
+                    clipPathURL: _this4.state.clipPathURL,
                     timeScale: _this4.props.timeScale,
                     yScale: _this4.state.yAxisScaleMap[child.props.axis]
                 };

--- a/lib/eventhandler.js
+++ b/lib/eventhandler.js
@@ -219,7 +219,8 @@ exports.default = _react2.default.createClass({
                 ref: "eventrect",
                 style: { opacity: 0.0, cursor: cursor },
                 x: 0, y: 0,
-                width: this.props.width, height: this.props.height }),
+                width: this.props.width,
+                height: this.props.height }),
             children
         );
     }

--- a/lib/labelaxis.js
+++ b/lib/labelaxis.js
@@ -4,17 +4,15 @@ Object.defineProperty(exports, "__esModule", {
     value: true
 });
 
+var _underscore = require("underscore");
+
+var _underscore2 = _interopRequireDefault(_underscore);
+
 var _react = require("react");
 
 var _react2 = _interopRequireDefault(_react);
 
-var _d = require("d3");
-
-var _d2 = _interopRequireDefault(_d);
-
-var _underscore = require("underscore");
-
-var _underscore2 = _interopRequireDefault(_underscore);
+var _d3Format = require("d3-format");
 
 var _valuelist = require("./valuelist");
 
@@ -76,9 +74,9 @@ exports.default = _react2.default.createClass({
             return _react2.default.createElement("g", null);
         }
         var valXPos = rectWidth + 3; // padding
-        var format = _underscore2.default.has(this.props, "format") ? this.props.format : ".2f";
-        var maxStr = _d2.default.format(format)(this.props.max);
-        var minStr = _d2.default.format(format)(this.props.min);
+        var fmt = _underscore2.default.has(this.props, "format") ? this.props.format : ".2f";
+        var maxStr = (0, _d3Format.format)(fmt)(this.props.max);
+        var minStr = (0, _d3Format.format)(fmt)(this.props.min);
 
         return _react2.default.createElement(
             "g",

--- a/lib/table.js
+++ b/lib/table.js
@@ -12,9 +12,7 @@ var _underscore = require("underscore");
 
 var _underscore2 = _interopRequireDefault(_underscore);
 
-var _d = require("d3");
-
-var _d2 = _interopRequireDefault(_d);
+var _d3Format = require("d3-format");
 
 var _moment = require("moment");
 
@@ -63,14 +61,14 @@ exports.default = _react2.default.createClass({
                         if (_underscore2.default.isFunction(column.format)) {
                             formatter = column.format;
                         } else if (_underscore2.default.isString(column.format)) {
-                            formatter = _d2.default.format(column.format);
+                            formatter = (0, _d3Format.format)(column.format);
                         }
                     }
 
                     if (column.key === "time") {
                         if (event instanceof _pondjs.IndexedEvent) {
-                            var format = _this.props.timeFormat;
-                            var eventIndex = event.index().toNiceString(format);
+                            var _format = _this.props.timeFormat;
+                            var eventIndex = event.index().toNiceString(_format);
                             cells.push(_react2.default.createElement(
                                 "td",
                                 { key: event.index().asString() },

--- a/lib/tracker.js
+++ b/lib/tracker.js
@@ -8,9 +8,7 @@ var _react = require("react");
 
 var _react2 = _interopRequireDefault(_react);
 
-var _d = require("d3");
-
-var _d2 = _interopRequireDefault(_d);
+var _d3TimeFormat = require("d3-time-format");
 
 var _moment = require("moment");
 
@@ -76,19 +74,19 @@ exports.default = _react2.default.createClass({
 
         var dateStr = "" + d;
         if (this.props.timeFormat === "day") {
-            var format = _d2.default.time.format("%d");
-            dateStr = format(d);
+            var formatter = (0, _d3TimeFormat.timeFormat)("%d");
+            dateStr = formatter(d);
         } else if (this.props.timeFormat === "month") {
-            var _format = _d2.default.time.format("%B");
-            dateStr = _format(d);
+            var _formatter = (0, _d3TimeFormat.timeFormat)("%B");
+            dateStr = _formatter(d);
         } else if (this.props.timeFormat === "year") {
-            var _format2 = _d2.default.time.format("%Y");
-            dateStr = _format2(d);
+            var _formatter2 = (0, _d3TimeFormat.timeFormat)("%Y");
+            dateStr = _formatter2(d);
         } else if (this.props.timeFormat === "relative") {
             dateStr = _moment2.default.duration(+d).format();
         } else {
-            var _format3 = _d2.default.time.format(this.props.timeFormat);
-            dateStr = _format3(d);
+            var _formatter3 = (0, _d3TimeFormat.timeFormat)(this.props.timeFormat);
+            dateStr = _formatter3(d);
         }
 
         return _react2.default.createElement(

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "url": "https://github.com/esnet/react-timeseries-charts/issues"
   },
   "scripts": {
-    "prepublish": "npm test && npm run build",
     "docs": "react-docgen src/ -x jsx -o examples/docs.json --pretty",
     "lint": "eslint src/*.jsx",
     "test": "npm run lint",
@@ -32,9 +31,8 @@
   "license": "BSD-3-Clause-LBNL",
   "dependencies": {
     "babel-runtime": "^6.5.0",
-    "d3": "^3.5.5",
     "d3-axis": "^0.3.0",
-    "d3-brush": "^0.1.2",
+    "d3-brush": "^0.1.6",
     "d3-ease": "^0.7.0",
     "d3-format": "^0.5.1",
     "d3-interpolate": "^0.7.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
   "dependencies": {
     "babel-runtime": "^6.5.0",
     "d3-axis": "^0.3.0",
-    "d3-brush": "^0.1.6",
     "d3-ease": "^0.7.0",
     "d3-format": "^0.5.1",
     "d3-interpolate": "^0.7.0",

--- a/src/brush.jsx
+++ b/src/brush.jsx
@@ -1,5 +1,5 @@
 /**
- *  Copyright (c) 2015, The Regents of the University of California,
+ *  Copyright (c) 2016, The Regents of the University of California,
  *  through Lawrence Berkeley National Laboratory (subject to receipt
  *  of any required approvals from the U.S. Dept. of Energy).
  *  All rights reserved.
@@ -9,72 +9,235 @@
  */
 
 import React from "react";
-import ReactDOM from "react-dom";
-import { brushX, brushSelection } from "d3-brush";
-import { select, event } from "d3-selection";
 import { TimeRange } from "pondjs";
 
-function scaleAsString(scale) {
-    return `${scale.domain().toString()}-${scale.range().toString()}`;
-}
-
+/**
+ * Renders a band with extents defined by the supplied TimeRange.
+ */
 export default React.createClass({
 
-    displayName: "Brush",
+    displayName: "TimeRangeMarker",
 
-    componentWillMount() {
-        this.brush = brushX()
-            .on("brush", this.handleBrushed);
+    propTypes: {
+        timeRange: React.PropTypes.instanceOf(TimeRange).isRequired,
+        style: React.PropTypes.object
     },
 
-    handleBrushed() {
-        const [x1, x2] = event.selection;
+    getDefaultProps() {
+        return {
+            spacing: 1,
+            offset: 0,
+            style: {
+                fill: "rgba(70, 130, 180, 0.25)"
+            }
+        };
+    },
 
-        const d1 = this.props.timeScale.invert(x1);
-        const d2 = this.props.timeScale.invert(x2);
-
-        this.currentBegin = d1.getTime();
-        this.currentEnd = d2.getTime();
-
-        if (this.props.onTimeRangeChanged) {
-            this.props.onTimeRangeChanged(new TimeRange(d1, d2));
+    getInitialState() {
+        return {
+            isBrushing: false
         }
     },
 
-    renderBrush(timeScale, timeRange) {
-        if (timeRange.begin().getTime() !== this.currentBegin ||
-            timeRange.end().getTime() !== this.currentEnd) {
+    handleBrushMouseDown(e) {
+        e.preventDefault();
 
-            const x1 = this.props.timeScale(timeRange.begin());
-            const x2 = this.props.timeScale(timeRange.end());
+        const x = e.pageX;
+        const y = e.pageY;
+        const xy0 = [Math.round(x), Math.round(y)];
+        const begin = this.props.timeRange.begin().getTime();
+        const end = this.props.timeRange.end().getTime();
 
-            select(this.refs.group).selectAll("*").remove();
-            select(this.refs.group)
-                .append("g")
-                    .attr("class", "brush")
-                    .call(this.brush)
-                    .call(this.brush.move, [x1, x2]);
+        this.setState({
+            isBrushing: true,
+            brushingInitializationSite: "brush",
+            initialBrushBeginTime: begin,
+            initialBrushEndTime: end,
+            initialBrushXYPosition: xy0
+        });
+    },
+
+    handleLeftHandleMouseDown(e) {
+        e.preventDefault();
+
+        const x = e.pageX;
+        const y = e.pageY;
+        const xy0 = [Math.round(x), Math.round(y)];
+        const begin = this.props.timeRange.begin().getTime();
+        const end = this.props.timeRange.end().getTime();
+
+        this.setState({
+            isBrushing: true,
+            brushingInitializationSite: "handle-left",
+            initialBrushBeginTime: begin,
+            initialBrushEndTime: end,
+            initialBrushXYPosition: xy0
+        });
+    },
+
+    handleRightHandleMouseDown(e) {
+        e.preventDefault();
+
+        const x = e.pageX;
+        const y = e.pageY;
+        const xy0 = [Math.round(x), Math.round(y)];
+        const begin = this.props.timeRange.begin().getTime();
+        const end = this.props.timeRange.end().getTime();
+
+        this.setState({
+            isBrushing: true,
+            brushingInitializationSite: "handle-right",
+            initialBrushBeginTime: begin,
+            initialBrushEndTime: end,
+            initialBrushXYPosition: xy0
+        });
+    },
+
+    handleMouseUp(e) {
+        e.preventDefault();
+        this.setState({
+            isBrushing: false,
+            brushingInitializationSite: null,
+            initialBrushBeginTime: null,
+            initialBrushEndTime: null,
+            initialBrushXYPosition: null
+        });
+    },
+
+    handleMouseMove(e) {
+        e.preventDefault();
+
+        const x = e.pageX;
+        const y = e.pageY;
+        const xy = [Math.round(x), Math.round(y)];
+
+        if (this.state.isBrushing) {
+            const xy0 = this.state.initialBrushXYPosition;
+
+            const timeOffset =
+                this.props.timeScale.invert(xy0[0]).getTime() -
+                this.props.timeScale.invert(xy[0]).getTime();
+
+            let newBegin =
+                this.state.brushingInitializationSite === "brush" ||
+                this.state.brushingInitializationSite === "handle-left" ?
+                    parseInt(this.state.initialBrushBeginTime - timeOffset, 10) :
+                    this.state.initialBrushBeginTime;
+
+            let newEnd =
+                this.state.brushingInitializationSite === "brush" ||
+                this.state.brushingInitializationSite === "handle-right" ?
+                    parseInt(this.state.initialBrushEndTime - timeOffset, 10) :
+                    this.state.initialBrushEndTime;
+
+            if (this.props.onTimeRangeChanged) {
+                this.props.onTimeRangeChanged(new TimeRange(newBegin, newEnd));
+            }
         }
     },
 
-    componentDidMount() {
-        this.renderBrush(this.props.timeScale, this.props.timeRange);
+    renderOverlay() {
+        const { width, height } = this.props;
+        const overlayStyle = {fill: "red", opacity: 0.1};
+        return (
+            <rect
+                x={0} y={0}
+                width={width} height={height}
+                style={overlayStyle}
+                clipPath={this.props.clipPathURL} />
+        );
     },
 
-    componentWillReceiveProps(nextProps) {
-        const timeScale = nextProps.timeScale;
-        const timeRange = nextProps.timeRange;
-        if (scaleAsString(this.props.timeScale) !== scaleAsString(timeScale) ||
-            this.props.timeRange !== timeRange) {
-            this.renderBrush(timeScale, timeRange);
+    renderBrush() {
+        const { timeRange, timeScale, width, height, style } = this.props;
+
+        // Viewport bounds
+        const viewBeginTime = timeScale.invert(0);
+        const viewEndTime = timeScale.invert(width);
+        const viewport = new TimeRange(viewBeginTime, viewEndTime);
+
+        // Style of the brush area
+        let brushStyle = style ? style : {fill: "steelblue"};
+        brushStyle.cursor = "move";
+
+        if (!viewport.disjoint(timeRange)) {
+            const range = timeRange.intersection(viewport);
+            const begin = range.begin();
+            const end = range.end();
+            const [ x, y ] = [timeScale(begin), 0];
+            const endPos = timeScale(end);
+            let width = endPos - x;
+            if (width < 1) {
+                width = 1;
+            }
+
+            const bounds = {x, y, width, height};
+
+            return (
+                <rect
+                    {...bounds}
+                    style={brushStyle}
+                    pointerEvents="all"
+                    onMouseDown={this.handleBrushMouseDown}
+                    onMouseUp={this.handleMouseUp}
+                    clipPath={this.props.clipPathURL} />
+            );
         }
     },
 
-    shouldComponentUpdate() {
-        return false;
+    renderHandles() {
+        const { timeRange, timeScale, width, height, style } = this.props;
+
+        // Viewport bounds
+        const viewBeginTime = timeScale.invert(0);
+        const viewEndTime = timeScale.invert(width);
+        const viewport = new TimeRange(viewBeginTime, viewEndTime);
+
+        // Style of the brush area
+        let handleStyle = {fill: "green", opacity: 0.1, cursor: "ew-resize"};
+
+        if (!viewport.disjoint(timeRange)) {
+            const range = timeRange.intersection(viewport);
+            const [ begin, end ] = range.toJSON();
+            const [ x, y ] = [timeScale(begin), 0];
+            const endPos = timeScale(end);
+            
+            let width = endPos - x;
+            if (width < 1) {
+                width = 1;
+            }
+
+            const handleWidth = 6;
+
+            const boundsHandleLeft = {x: x - handleWidth/2, y, width: handleWidth, height};
+            const boundsHandleRight = {x: x + width - handleWidth/2, y, width: handleWidth, height};
+
+            return (
+                <g>
+                    <rect
+                        {...boundsHandleLeft}
+                        style={handleStyle}
+                        pointerEvents="all"
+                        onMouseDown={this.handleLeftHandleMouseDown}
+                        onMouseUp={this.handleMouseUp} />
+                    <rect
+                        {...boundsHandleRight}
+                        style={handleStyle}
+                        pointerEvents="all"
+                        onMouseDown={this.handleRightHandleMouseDown}
+                        onMouseUp={this.handleMouseUp} />
+                </g>
+            );
+        }
     },
 
     render() {
-        return <g ref="group"/>;
+        return (
+            <g onMouseMove={this.handleMouseMove}>
+                {this.renderOverlay()}
+                {this.renderBrush()}
+                {this.renderHandles()}
+            </g>
+        );
     }
 });

--- a/src/brush.jsx
+++ b/src/brush.jsx
@@ -205,10 +205,24 @@ export default React.createClass({
 
     renderOverlay() {
         const { width, height } = this.props;
+
+        let cursor;
+        switch (this.state.brushingInitializationSite) {
+            case "handle-right":
+            case "handle-left":
+                cursor = "ew-resize";
+                break;
+            case "brush":
+                cursor = "move";
+                break;
+            default:
+                cursor = "crosshair";
+        }
+
         const overlayStyle = {
             fill: "white",
             opacity: 0,
-            cursor: "crosshair"
+            cursor
         };
         return (
             <rect
@@ -225,13 +239,26 @@ export default React.createClass({
     renderBrush() {
         const { timeRange, timeScale, height, style } = this.props;
 
+        let cursor;
+        switch (this.state.brushingInitializationSite) {
+            case "handle-right":
+            case "handle-left":
+                cursor = "ew-resize";
+                break;
+            case "overlay":
+                cursor = "crosshair";
+                break;
+            default:
+                cursor = "move";
+        }
+
         // Style of the brush area
         const brushDefaultStyle = {
             fill: "#777",
             fillOpacity: 0.3,
             stroke: "#fff",
             shapeRendering: "crispEdges",
-            cursor: "move"
+            cursor
         };
         const brushStyle = merge(true, brushDefaultStyle, style);
 
@@ -284,9 +311,9 @@ export default React.createClass({
             const handleSize = this.props.handleSize;
 
             const leftHandleBounds =
-                {x, y, width: handleSize, height};
+                {x: x - 1, y, width: handleSize, height};
             const rightHandleBounds =
-                {x: x + width - handleSize, y, width: handleSize, height};
+                {x: x + width - handleSize, y, width: handleSize + 1, height};
 
             return (
                 <g>

--- a/src/brush.jsx
+++ b/src/brush.jsx
@@ -9,6 +9,7 @@
  */
 
 import React from "react";
+import merge from "merge";
 import { TimeRange } from "pondjs";
 
 // http://stackoverflow.com/a/28857255
@@ -21,11 +22,11 @@ function getElementOffset(element) {
 }
 
 /**
- * Renders a band with extents defined by the supplied TimeRange.
+ * Renders a brush with the range defined in the prop `timeRange`.
  */
 export default React.createClass({
 
-    displayName: "TimeRangeMarker",
+    displayName: "Brush",
 
     propTypes: {
         timeRange: React.PropTypes.instanceOf(TimeRange).isRequired,
@@ -34,11 +35,7 @@ export default React.createClass({
 
     getDefaultProps() {
         return {
-            spacing: 1,
-            offset: 0,
-            style: {
-                fill: "rgba(70, 130, 180, 0.25)"
-            }
+            handleSize: 6
         };
     },
 
@@ -175,8 +172,8 @@ export default React.createClass({
     renderOverlay() {
         const { width, height } = this.props;
         const overlayStyle = {
-            fill: "red",
-            opacity: 0.1,
+            fill: "white",
+            opacity: 0,
             cursor: "crosshair"
         };
         return (
@@ -200,8 +197,14 @@ export default React.createClass({
         const viewport = new TimeRange(viewBeginTime, viewEndTime);
 
         // Style of the brush area
-        let brushStyle = style ? style : {fill: "steelblue"};
-        brushStyle.cursor = "move";
+        const brushDefaultStyle = {
+            fill: "#777",
+            fillOpacity: 0.3,
+            stroke: "#fff",
+            shapeRendering: "crispEdges",
+            cursor: "move"
+        };
+        const brushStyle = merge(true, brushDefaultStyle, style);
 
         if (!viewport.disjoint(timeRange)) {
             const range = timeRange.intersection(viewport);
@@ -236,8 +239,12 @@ export default React.createClass({
         const viewEndTime = timeScale.invert(width);
         const viewport = new TimeRange(viewBeginTime, viewEndTime);
 
-        // Style of the brush area
-        let handleStyle = {fill: "green", opacity: 0.1, cursor: "ew-resize"};
+        // Style of the handles
+        const handleStyle = {
+            fill: "white",
+            opacity: 0,
+            cursor: "ew-resize"
+        };
 
         if (!viewport.disjoint(timeRange)) {
             const range = timeRange.intersection(viewport);
@@ -250,10 +257,10 @@ export default React.createClass({
                 width = 1;
             }
 
-            const handleWidth = 6;
+            const handleSize = this.props.handleSize;
 
-            const boundsHandleLeft = {x: x - handleWidth/2, y, width: handleWidth, height};
-            const boundsHandleRight = {x: x + width - handleWidth/2, y, width: handleWidth, height};
+            const boundsHandleLeft = {x: x, y, width: handleSize, height};
+            const boundsHandleRight = {x: x + width - handleSize, y, width: handleSize, height};
 
             return (
                 <g>

--- a/src/chartrow.jsx
+++ b/src/chartrow.jsx
@@ -426,6 +426,7 @@ export default React.createClass({
                     key: `brush-${keyCount}`,
                     width: chartWidth,
                     height: innerHeight,
+                    clipPathURL: this.state.clipPathURL,
                     timeScale: this.props.timeScale,
                     yScale: this.state.yAxisScaleMap[child.props.axis]
                 };

--- a/src/eventhandler.jsx
+++ b/src/eventhandler.jsx
@@ -215,7 +215,8 @@ export default React.createClass({
                     ref="eventrect"
                     style={{opacity: 0.0, cursor}}
                     x={0} y={0}
-                    width={this.props.width} height={this.props.height} />
+                    width={this.props.width}
+                    height={this.props.height} />
                 {children}
             </g>
         );

--- a/src/labelaxis.jsx
+++ b/src/labelaxis.jsx
@@ -8,10 +8,9 @@
  *  LICENSE file in the root directory of this source tree.
  */
 
-import React from "react";
-import d3 from "d3";
 import _ from "underscore";
-
+import React from "react";
+import { format } from "d3-format";
 import ValueList from "./valuelist";
 
 /**
@@ -65,9 +64,9 @@ export default React.createClass({
             );
         }
         const valXPos = rectWidth + 3; // padding
-        const format = _.has(this.props, "format") ? this.props.format : ".2f";
-        const maxStr = d3.format(format)(this.props.max);
-        const minStr = d3.format(format)(this.props.min);
+        const fmt = _.has(this.props, "format") ? this.props.format : ".2f";
+        const maxStr = format(fmt)(this.props.max);
+        const minStr = format(fmt)(this.props.min);
 
         return (
             <g>

--- a/src/linechart.jsx
+++ b/src/linechart.jsx
@@ -12,7 +12,6 @@ import React from "react";
 import _ from "underscore";
 import d3Shape from "d3-shape";
 import merge from "merge";
-
 import { TimeSeries } from "pondjs";
 
 function scaleAsString(scale) {

--- a/src/table.jsx
+++ b/src/table.jsx
@@ -10,7 +10,7 @@
 
 import React from "react";
 import _ from "underscore";
-import d3 from "d3";
+import { format } from "d3-format";
 import Moment from "moment";
 
 import { TimeSeries, IndexedEvent } from "pondjs";
@@ -49,7 +49,7 @@ export default React.createClass({
                         if (_.isFunction(column.format)) {
                             formatter = column.format;
                         } else if (_.isString(column.format)) {
-                            formatter = d3.format(column.format);
+                            formatter = format(column.format);
                         }
                     }
 

--- a/src/tracker.jsx
+++ b/src/tracker.jsx
@@ -9,7 +9,6 @@
  */
 
 import React from "react";
-import { format } from "d3-format";
 import { timeFormat } from "d3-time-format";
 import moment from "moment";
 import "moment-duration-format";
@@ -81,7 +80,7 @@ export default React.createClass({
             const formatter = timeFormat("%Y");
             dateStr = formatter(d);
         } else if (this.props.timeFormat === "relative") {
-            dateStr = moment.duration(+d).formatter();
+            dateStr = moment.duration(+d).format();
         } else {
             const formatter = timeFormat(this.props.timeFormat);
             dateStr = formatter(d);

--- a/src/tracker.jsx
+++ b/src/tracker.jsx
@@ -9,7 +9,8 @@
  */
 
 import React from "react";
-import d3 from "d3";
+import { format } from "d3-format";
+import { timeFormat } from "d3-time-format";
 import moment from "moment";
 import "moment-duration-format";
 
@@ -71,19 +72,19 @@ export default React.createClass({
 
         let dateStr = `${d}`;
         if (this.props.timeFormat === "day") {
-            const format = d3.time.format("%d");
-            dateStr = format(d);
+            const formatter = timeFormat("%d");
+            dateStr = formatter(d);
         } else if (this.props.timeFormat === "month") {
-            const format = d3.time.format("%B");
-            dateStr = format(d);
+            const formatter = timeFormat("%B");
+            dateStr = formatter(d);
         } else if (this.props.timeFormat === "year") {
-            const format = d3.time.format("%Y");
-            dateStr = format(d);
+            const formatter = timeFormat("%Y");
+            dateStr = formatter(d);
         } else if (this.props.timeFormat === "relative") {
-            dateStr = moment.duration(+d).format();
+            dateStr = moment.duration(+d).formatter();
         } else {
-            const format = d3.time.format(this.props.timeFormat);
-            dateStr = format(d);
+            const formatter = timeFormat(this.props.timeFormat);
+            dateStr = formatter(d);
         }
 
         return (


### PR DESCRIPTION
Reimplements brushing code from scratch with react. Removes d3. Addresses the goals of #55. 

The reason for this is that either we depend on the whole of d3 v3.x for just the brush code, or we use d3-brush, whose API isn't well aligned with our use-case anymore and is far less flexible and friendly to future work on this code. Ultimately we're just drawing a rectangle here and handling the event permutations.

![brushing_example](https://cloud.githubusercontent.com/assets/1288813/15832641/efdbf54e-2bd7-11e6-9d10-b35da8905e2d.gif)

Features:
 * Handles initial brush areas
 * Handles clearing of brush areas with a background click. Fixes #47.
 * Brush may be changed by dragging the sides of the rect (the handles) or dragging the brush itself
 * A new brush can be created by dragging across the background area
 * Brush is constrained to the chart area it is placed in
 * Brush may be fully styled

This pull request also removes the last pieces of d3 v3 from the codebase.

@apertome Adding you as a cc on this, since you were playing around with the old brush code. This should address your original request, and make it a lot easier to change in the future. I hope this doesn't cause too much trouble, but I think it's better in the long run.
