### PR TITLE
Show negative values in BarChart

### DIFF
--- a/lib/components/BarChart.js
+++ b/lib/components/BarChart.js
@@ -381,8 +381,10 @@ exports.default = _react2.default.createClass({
                             var style = _this.style(column, event);
 
                             var height = yScale(0) - yScale(value);
-                            height = height < 1 ? 1 : height;
-                            var y = ypos - height;
+                            // Allow negative values. Minimum bar height = 1 pixel.
+                            height = Math.abs(height) < 1 ? 1 : height;
+                            var y = height > 0 ? ypos - height : ypos;
+                            height = height < 0 ? -height : height;
 
                             // Event marker if info provided and hovering
                             var isHighlighted = _this.props.highlighted && column === _this.props.highlighted.column && _pondjs.Event.is(_this.props.highlighted.event, event);

--- a/lib/components/BarChart.js
+++ b/lib/components/BarChart.js
@@ -365,7 +365,8 @@ exports.default = _react2.default.createClass({
                 }
 
                 var yBase = yScale(0);
-                var ypos = yBase;
+                var yposPositive = yBase;
+                var yposNegative = yBase;
                 if (columns) {
                     var _iteratorNormalCompletion2 = true;
                     var _didIteratorError2 = false;
@@ -382,16 +383,17 @@ exports.default = _react2.default.createClass({
 
                             var height = yScale(0) - yScale(value);
                             // Allow negative values. Minimum bar height = 1 pixel.
-                            height = Math.abs(height) < 1 ? 1 : height;
-                            var y = height > 0 ? ypos - height : ypos;
-                            height = height < 0 ? -height : height;
+                            // Stack negative bars below X-axis and positive above X-Axis
+                            var positiveBar = height >= 0;
+                            height = Math.max(Math.abs(height), 1);
+                            var y = positiveBar ? yposPositive - height : yposNegative;
 
                             // Event marker if info provided and hovering
                             var isHighlighted = _this.props.highlighted && column === _this.props.highlighted.column && _pondjs.Event.is(_this.props.highlighted.event, event);
                             if (isHighlighted && _this.props.info) {
                                 eventMarker = _react2.default.createElement(_EventMarker2.default, _extends({}, _this.props, {
                                     offsetX: offset,
-                                    offsetY: yBase - ypos,
+                                    offsetY: yBase - (positiveBar ? yposPositive : yposNegative),
                                     event: event,
                                     column: column }));
                             }
@@ -413,7 +415,11 @@ exports.default = _react2.default.createClass({
 
                             bars.push(_react2.default.createElement("rect", barProps));
 
-                            ypos -= height;
+                            if (positiveBar) {
+                                yposPositive -= height;
+                            } else {
+                                yposNegative += height;
+                            }
                         };
 
                         for (var _iterator2 = columns[Symbol.iterator](), _step2; !(_iteratorNormalCompletion2 = (_step2 = _iterator2.next()).done); _iteratorNormalCompletion2 = true) {

--- a/src/components/BarChart.js
+++ b/src/components/BarChart.js
@@ -369,8 +369,10 @@ export default React.createClass({
                     const style = this.style(column, event);
 
                     let height = yScale(0) - yScale(value);
-                    height = height < 1 ? 1 : height;
-                    const y = ypos - height;
+                    // Allow negative values. Minimum bar height = 1 pixel.
+                    height = Math.abs(height) < 1 ? 1 : height;
+                    const y = height > 0 ? ypos - height : ypos;
+                    height = height < 0 ? -height : height;
 
                     // Event marker if info provided and hovering
                     const isHighlighted = this.props.highlighted &&

--- a/src/components/BarChart.js
+++ b/src/components/BarChart.js
@@ -360,7 +360,8 @@ export default React.createClass({
             }
 
             const yBase = yScale(0);
-            let ypos = yBase;
+            let yposPositive = yBase;
+            let yposNegative = yBase;
             if (columns) {
                 for (const column of columns) {
                     const index = event.index();
@@ -370,9 +371,10 @@ export default React.createClass({
 
                     let height = yScale(0) - yScale(value);
                     // Allow negative values. Minimum bar height = 1 pixel.
-                    height = Math.abs(height) < 1 ? 1 : height;
-                    const y = height > 0 ? ypos - height : ypos;
-                    height = height < 0 ? -height : height;
+                    // Stack negative bars below X-axis and positive above X-Axis
+                    const positiveBar = height >= 0;
+                    height = Math.max(Math.abs(height), 1);
+                    const y = positiveBar ? yposPositive - height : yposNegative;
 
                     // Event marker if info provided and hovering
                     const isHighlighted = this.props.highlighted &&
@@ -383,7 +385,7 @@ export default React.createClass({
                             <EventMarker
                                 {...this.props}
                                 offsetX={offset}
-                                offsetY={yBase - ypos}
+                                offsetY={yBase - (positiveBar ? yposPositive : yposNegative)}
                                 event={event}
                                 column={column} />
                         );
@@ -404,7 +406,11 @@ export default React.createClass({
                         <rect {...barProps} />
                     );
 
-                    ypos -= height;
+                    if (positiveBar) {
+                        yposPositive -= height;
+                    } else {
+                        yposNegative += height;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Also, keep minimum bar height of 1 pixel (although this can be questioned).

Fixes #94.

Regarding following the guidelines: I did not make an example as adding a negative value to the existing traffic charts is not logical. If this is an issue, please instruct me where to put an example in the website.