### PR TITLE
Change Wind example ScatterChart prop from selection to selected to fix selection highlighting

### DIFF
--- a/src/components/ScatterChart.js
+++ b/src/components/ScatterChart.js
@@ -401,7 +401,10 @@ ScatterChart.propTypes = {
    *
    * See also `onSelectionChange`
    */
-  selected: PropTypes.string,
+  selected: PropTypes.arrayOf(PropTypes.shape({
+    event: PropTypes.instanceOf(Event),
+    column: PropTypes.string
+  })),
   /**
    * A callback that will be called when the selection changes. It will be called
    * with an object containing the event and column.

--- a/src/website/api/docs.json
+++ b/src/website/api/docs.json
@@ -3288,7 +3288,18 @@
       },
       "selected": {
         "type": {
-          "name": "string"
+          "name": "shape",
+          "value": {
+            "event": {
+              "name": "instanceOf",
+              "value": "Event",
+              "required": false
+            },
+            "column": {
+              "name": "string",
+              "required": false
+            }
+          }
         },
         "required": false,
         "description": "The selected dot, which will be rendered in the \"selected\" style.\nIf a dot is selected, all other dots will be rendered in the \"muted\" style.\n\nSee also `onSelectionChange`"

--- a/src/website/examples/wind/Index.js
+++ b/src/website/examples/wind/Index.js
@@ -184,7 +184,7 @@ const wind = React.createClass({
                                                 color: "#DDD"
                                             }}
                                             format=".1f"
-                                            selection={this.state.selection}
+                                            selected={this.state.selection}
                                             onSelectionChange={
                                                 (p) => this.handleSelectionChanged(p)
                                             }

--- a/src/website/examples/wind/wind_docs.md
+++ b/src/website/examples/wind/wind_docs.md
@@ -86,7 +86,7 @@ Here is the render code:
                         color: "#DDD"
                     }}
                     format=".1f"
-                    selection={this.state.selection}
+                    selected={this.state.selection}
                     onSelectionChange={
                         this.handleSelectionChanged
                     }


### PR DESCRIPTION
In the wind example, the ScatterChart component is passed selection instead of selected as outlined in the docs. After changing `selection` to `selected`, the selection functionality works when you click on an event. ScatterChart's PropTypes expect `selected` to be a string, but it should be an object. This PR updates PropTypes and associated documentation about selected for ScatterChart. 

After changing selection to selected.
![may-23-2017 15-58-56](https://cloud.githubusercontent.com/assets/7112158/26379990/d0d055f6-3fd0-11e7-9032-fc6196730c5c.gif)

<img width="1649" alt="screen shot 2017-05-23 at 4 02 13 pm" src="https://cloud.githubusercontent.com/assets/7112158/26380093/5c96ce80-3fd1-11e7-969a-71383cbec81e.png">
