### PR TITLE
Address #211 - Allow YAxis style functions

### DIFF
--- a/src/components/YAxis.js
+++ b/src/components/YAxis.js
@@ -396,7 +396,10 @@ YAxis.propTypes = {
     labelOffset: PropTypes.number,
 
     /**
-     * d3.format for the axis labels. e.g. `format="$,.2f"`
+     * If a string, the d3.format for the axis labels (e.g. `format=\"$,.2f\"`).
+     * If a function, that function will be called with each tick value and
+     * should generate a formatted string for that value to be used as the label
+     * for that tick (e.g. `function (n) { return Number(n).toFixed(2) }`).
      */
     format: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
 

--- a/src/components/YAxis.js
+++ b/src/components/YAxis.js
@@ -9,6 +9,7 @@
  */
 
 import "d3-transition";
+import _ from "underscore";
 import merge from "merge";
 import React from "react";
 import ReactDOM from "react-dom"; // eslint-disable-line
@@ -115,8 +116,18 @@ export default class YAxis extends React.Component {
         return false;
     }
 
+    yformat(fmt) {
+        if (_.isString(fmt)) {
+            return format(fmt);
+        } else if (_.isFunction(fmt)) {
+            return fmt;
+        } else {
+            return format("");
+        }
+    }
+
     updateAxis(align, scale, width, absolute, type, fmt) {
-        const yformat = format(fmt);
+        const yformat = this.yformat(fmt);
         const axis = align === "left" ? axisLeft : axisRight;
 
         const axisStyle = merge(
@@ -175,7 +186,7 @@ export default class YAxis extends React.Component {
     }
 
     renderAxis(align, scale, width, absolute, fmt) {
-        const yformat = format(fmt);
+        const yformat = this.yformat(fmt);
         let axisGenerator;
         const axis = align === "left" ? axisLeft : axisRight;
         if (this.props.type === "linear" || this.props.type === "power") {
@@ -387,7 +398,7 @@ YAxis.propTypes = {
     /**
      * d3.format for the axis labels. e.g. `format="$,.2f"`
      */
-    format: PropTypes.string,
+    format: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
 
     /**
      * If the chart should be rendered to with the axis on the left or right.

--- a/src/website/components/API.js
+++ b/src/website/components/API.js
@@ -16,7 +16,7 @@ import { Link } from "react-router";
 import _ from "underscore";
 import Flexbox from "flexbox-react";
 
-import Highlighter from "./Highlighter";
+import Highlighter from "./highlighter";
 import APIDoc from "./APIDoc";
 
 import Meta from "../packages/charts/examples/examples.json";

--- a/src/website/components/Example.js
+++ b/src/website/components/Example.js
@@ -11,7 +11,7 @@
 import React from "react";
 import createReactClass from "create-react-class";
 import Markdown from "react-markdown";
-import Highlighter from "./Highlighter";
+import Highlighter from "./highlighter";
 import Examples from "../packages/charts/examples/examples.js";
 import Meta from "../packages/charts/examples/examples.json";
 

--- a/src/website/components/Guide.js
+++ b/src/website/components/Guide.js
@@ -10,7 +10,7 @@
 
 import React from "react";
 import createReactClass from "create-react-class";
-import Highlighter from "./Highlighter";
+import Highlighter from "./highlighter";
 import Markdown from "react-markdown";
 
 import Guides from "../packages/charts/guides/guides";

--- a/src/website/packages/charts/api/docs.json
+++ b/src/website/packages/charts/api/docs.json
@@ -4123,10 +4123,18 @@
       },
       "format": {
         "type": {
-          "name": "string"
+          "name": "union",
+          "value": [
+            {
+              "name": "string"
+            },
+            {
+              "name": "func"
+            }
+          ]
         },
         "required": false,
-        "description": "d3.format for the axis labels. e.g. `format=\"$,.2f\"`",
+        "description": "If a string, the d3.format for the axis labels (e.g. `format=\"$,.2f\"`). If a function, that function will be called with each tick value and should generate a formatted string for that value to be used as the label for that tick (e.g. `function (n) { return Number(n).toFixed(2) }`).",
         "defaultValue": {
           "value": "\".2s\"",
           "computed": false

--- a/src/website/packages/charts/api/docs.json
+++ b/src/website/packages/charts/api/docs.json
@@ -4123,18 +4123,10 @@
       },
       "format": {
         "type": {
-          "name": "union",
-          "value": [
-            {
-              "name": "string"
-            },
-            {
-              "name": "func"
-            }
-          ]
+          "name": "string"
         },
         "required": false,
-        "description": "If a string, the d3.format for the axis labels (e.g. `format=\"$,.2f\"`). If a function, that function will be called with each tick value and should generate a formatted string for that value to be used as the label for that tick (e.g. `function (n) { return Number(n).toFixed(2) }`).",
+        "description": "d3.format for the axis labels. e.g. `format=\"$,.2f\"`",
         "defaultValue": {
           "value": "\".2s\"",
           "computed": false

--- a/src/website/packages/charts/examples/nyc/Index.js
+++ b/src/website/packages/charts/examples/nyc/Index.js
@@ -134,6 +134,7 @@ class nyc extends React.Component {
                                         min={0}
                                         max={120}
                                         width="70"
+                                        format={n => Number(n).toFixed() + "°F"}
                                     />
                                 </ChartRow>
                             </ChartContainer>

--- a/src/website/packages/charts/examples/nyc/nyc_docs.md
+++ b/src/website/packages/charts/examples/nyc/nyc_docs.md
@@ -33,7 +33,7 @@ First we need to import out data, which is in a CSV file that we read in as `wea
     const series = new TimeSeries({ name, new Collection(events) });
 ```
 
-We can then render our `series`:
+We can then render our `series`. Note that this example also demonstrates the ability to pass a function, rather than a d3 format string, as the `YAxis` format property.
 
 ```
     render() {
@@ -55,7 +55,8 @@ We can then render our `series`:
                             id="temp"
                             label="Temperature"
                             min={0} max={120}
-                            width="70" />
+                            width="70"
+                            format={ n => Number(n).toFixed() + "°F" } />
                     </ChartRow>
                 </ChartContainer>
             ...


### PR DESCRIPTION
- Allow a function to be passed as the `YAxis` format prop and use that function to generate axis labels.
- Update API docs.
- Use a format function in the NYC example.

Note: I also fixed the case on imports of `highlighter.js`, since it seemed to be causing problems on a fresh `npm install`.