### PR TITLE
fix onBackgroundClick event handling when enablePanZoom=false

### DIFF
--- a/src/components/EventHandler.js
+++ b/src/components/EventHandler.js
@@ -132,7 +132,7 @@ export default class EventHandler extends React.Component {
         document.addEventListener("mouseup", this.handleMouseUp);
 
         this.setState({
-            isPanning: this.props.enablePanZoom && true,
+            isPanning: this.props.enablePanZoom,
             initialPanBegin: begin,
             initialPanEnd: end,
             initialPanPosition: xy0

--- a/src/components/EventHandler.js
+++ b/src/components/EventHandler.js
@@ -119,10 +119,6 @@ export default class EventHandler extends React.Component {
     }
 
     handleMouseDown(e) {
-        if (!this.props.enablePanZoom) {
-            return;
-        }
-
         e.preventDefault();
 
         const x = e.pageX;
@@ -136,7 +132,7 @@ export default class EventHandler extends React.Component {
         document.addEventListener("mouseup", this.handleMouseUp);
 
         this.setState({
-            isPanning: true,
+            isPanning: this.props.enablePanZoom && true,
             initialPanBegin: begin,
             initialPanEnd: end,
             initialPanPosition: xy0
@@ -146,10 +142,6 @@ export default class EventHandler extends React.Component {
     }
 
     handleMouseUp(e) {
-        if (!this.props.enablePanZoom) {
-            return;
-        }
-
         e.stopPropagation();
 
         document.removeEventListener("mouseover", this.handleMouseMove);


### PR DESCRIPTION
`onBackgroundClick` event is never reached if `enablePanZoom=false` 

This bug can be noticed in the continents example where clicking in the background won't remove the selection http://software.es.net/react-timeseries-charts/#/example/continents

https://github.com/esnet/react-timeseries-charts/blob/master/src/website/packages/charts/examples/continents/Index.js#L124

Let me know if I missed something. I verified all the other examples and they're working as intended in regards to zooming/panning. 