### PR TITLE
Add feature - Show data gaps in AreaCharts

### DIFF
--- a/lib/components/AreaChart.js
+++ b/lib/components/AreaChart.js
@@ -331,90 +331,150 @@ var AreaChart = (function(_React$Component) {
             }
         },
         {
+            key: "renderArea",
+            value: function renderArea(data, column, key) {
+                var _this2 = this;
+
+                // Use D3 to build an area generation function
+                var style = this.areaStyle(column);
+                var pathStyle = this.pathStyle(column);
+
+                var areaGenerator = (0, _d3Shape.area)()
+                    .curve(_curve2.default[this.props.interpolation])
+                    .x(function(d) {
+                        return d.x0;
+                    })
+                    .y0(function(d) {
+                        return d.y0;
+                    })
+                    .y1(function(d) {
+                        return d.y1;
+                    });
+
+                // Use the area generation function with our stacked data
+                // to get an SVG path
+                var areaPath = areaGenerator(data);
+
+                // Outline the top of the curve
+                var lineGenerator = (0, _d3Shape.line)()
+                    .curve(_curve2.default[this.props.interpolation])
+                    .x(function(d) {
+                        return d.x0;
+                    })
+                    .y(function(d) {
+                        return d.y1;
+                    });
+                var outlinePath = lineGenerator(data);
+
+                return _react2.default.createElement(
+                    "g",
+                    { key: "area-" + key },
+                    _react2.default.createElement("path", { d: areaPath, style: style }),
+                    _react2.default.createElement("path", {
+                        d: areaPath,
+                        style: style,
+                        onClick: function onClick(e) {
+                            return _this2.handleClick(e, column);
+                        },
+                        onMouseLeave: function onMouseLeave() {
+                            return _this2.handleHoverLeave();
+                        },
+                        onMouseMove: function onMouseMove(e) {
+                            return _this2.handleHover(e, column);
+                        }
+                    }),
+                    _react2.default.createElement("path", {
+                        d: outlinePath,
+                        style: pathStyle,
+                        onClick: function onClick(e) {
+                            return _this2.handleClick(e, column);
+                        },
+                        onMouseLeave: function onMouseLeave() {
+                            return _this2.handleHoverLeave();
+                        },
+                        onMouseMove: function onMouseMove(e) {
+                            return _this2.handleHover(e, column);
+                        }
+                    })
+                );
+            }
+        },
+        {
             key: "renderPaths",
             value: function renderPaths(columnList, direction) {
-                var _this2 = this;
+                var _this3 = this;
 
                 var dir = direction === "up" ? 1 : -1;
                 var size = this.props.series.size();
                 var offsets = new Array(size).fill(0);
 
                 return columnList.map(function(column, i) {
-                    var style = _this2.areaStyle(column);
-                    var pathStyle = _this2.pathStyle(column);
-
                     // Stack the series columns to get our data in x0, y0, y1 format
-                    var data = [];
-                    for (var j = 0; j < _this2.props.series.size(); j += 1) {
-                        var seriesPoint = _this2.props.series.at(j);
-                        data.push({
-                            x0: _this2.props.timeScale(seriesPoint.timestamp()),
-                            y0: _this2.props.yScale(offsets[j]),
-                            y1: _this2.props.yScale(offsets[j] + dir * seriesPoint.get(column))
-                        });
-                        if (_this2.props.stack) {
-                            offsets[j] += dir * seriesPoint.get(column);
+                    var pathAreas = [];
+                    var count = 1;
+                    if (_this3.props.breakArea) {
+                        // Remove nulls and NaNs from the area chart by generating a break in the area chart
+                        var currentPoints = null;
+                        for (var j = 0; j < _this3.props.series.size(); j += 1) {
+                            var seriesPoint = _this3.props.series.at(j);
+                            var value = seriesPoint.get(column);
+                            var badPoint =
+                                _underscore2.default.isNull(value) ||
+                                _underscore2.default.isNaN(value) ||
+                                !_underscore2.default.isFinite(value);
+                            if (!badPoint) {
+                                if (!currentPoints) currentPoints = [];
+                                currentPoints.push({
+                                    x0: _this3.props.timeScale(seriesPoint.timestamp()),
+                                    y0: _this3.props.yScale(offsets[j]),
+                                    y1: _this3.props.yScale(
+                                        offsets[j] + dir * seriesPoint.get(column)
+                                    )
+                                });
+                                if (_this3.props.stack) {
+                                    offsets[j] += dir * seriesPoint.get(column);
+                                }
+                            } else if (currentPoints) {
+                                if (currentPoints.length > 1) {
+                                    pathAreas.push(_this3.renderArea(currentPoints, column, count));
+                                    count += 1;
+                                }
+                                currentPoints = null;
+                            }
                         }
+                        if (currentPoints && currentPoints.length > 1) {
+                            pathAreas.push(_this3.renderArea(currentPoints, column, count));
+                            count += 1;
+                        }
+                    } else {
+                        // Ignore nulls and NaNs in the area chart
+                        var cleanedPoints = [];
+                        for (var _j = 0; _j < _this3.props.series.size(); _j += 1) {
+                            var _seriesPoint = _this3.props.series.at(_j);
+                            var _value = _seriesPoint.get(column);
+                            var _badPoint =
+                                _underscore2.default.isNull(_value) ||
+                                _underscore2.default.isNaN(_value) ||
+                                !_underscore2.default.isFinite(_value);
+                            if (!_badPoint) {
+                                cleanedPoints.push({
+                                    x0: _this3.props.timeScale(_seriesPoint.timestamp()),
+                                    y0: _this3.props.yScale(offsets[_j]),
+                                    y1: _this3.props.yScale(
+                                        offsets[_j] + dir * _seriesPoint.get(column)
+                                    )
+                                });
+                                if (_this3.props.stack) {
+                                    offsets[_j] += dir * _seriesPoint.get(column);
+                                }
+                            }
+                        }
+
+                        pathAreas.push(_this3.renderArea(cleanedPoints, column, count));
+                        count += 1;
                     }
 
-                    // Use D3 to build an area generation function
-                    var areaGenerator = (0, _d3Shape.area)()
-                        .curve(_curve2.default[_this2.props.interpolation])
-                        .x(function(d) {
-                            return d.x0;
-                        })
-                        .y0(function(d) {
-                            return d.y0;
-                        })
-                        .y1(function(d) {
-                            return d.y1;
-                        });
-
-                    // Use the area generation function with our stacked data
-                    // to get an SVG path
-                    var areaPath = areaGenerator(data);
-
-                    // Outline the top of the curve
-                    var lineGenerator = (0, _d3Shape.line)()
-                        .curve(_curve2.default[_this2.props.interpolation])
-                        .x(function(d) {
-                            return d.x0;
-                        })
-                        .y(function(d) {
-                            return d.y1;
-                        });
-                    var outlinePath = lineGenerator(data);
-
-                    return _react2.default.createElement(
-                        "g",
-                        { key: "area-" + i },
-                        _react2.default.createElement("path", {
-                            d: areaPath,
-                            style: style,
-                            onClick: function onClick(e) {
-                                return _this2.handleClick(e, column);
-                            },
-                            onMouseLeave: function onMouseLeave() {
-                                return _this2.handleHoverLeave();
-                            },
-                            onMouseMove: function onMouseMove(e) {
-                                return _this2.handleHover(e, column);
-                            }
-                        }),
-                        _react2.default.createElement("path", {
-                            d: outlinePath,
-                            style: pathStyle,
-                            onClick: function onClick(e) {
-                                return _this2.handleClick(e, column);
-                            },
-                            onMouseLeave: function onMouseLeave() {
-                                return _this2.handleHoverLeave();
-                            },
-                            onMouseMove: function onMouseMove(e) {
-                                return _this2.handleHover(e, column);
-                            }
-                        })
-                    );
+                    return _react2.default.createElement("g", { key: column }, pathAreas);
                 });
             }
         },
@@ -582,7 +642,16 @@ AreaChart.propTypes = {
     /**
      * [Internal] The width supplied by the surrounding ChartContainer
      */
-    width: _propTypes2.default.number
+    width: _propTypes2.default.number,
+
+    /**
+     * The determines how to handle bad/missing values in the supplied
+     * TimeSeries. A missing value can be null or NaN. If breakArea
+     * is set to true then the area chart will be broken on either side of
+     * the bad value(s). If breakArea is false (the default) bad values
+     * are simply removed and the adjoining points are connected.
+     */
+    breakArea: _propTypes2.default.bool
 };
 
 AreaChart.defaultProps = {
@@ -592,5 +661,6 @@ AreaChart.defaultProps = {
         up: ["value"],
         down: []
     },
-    stack: true
+    stack: true,
+    breakArea: true
 };

--- a/src/components/AreaChart.js
+++ b/src/components/AreaChart.js
@@ -228,65 +228,111 @@ export default class AreaChart extends React.Component {
         return this.style(column, "area");
     }
 
+    renderArea(data, column, key) {
+        // Use D3 to build an area generation function
+        const style = this.areaStyle(column);
+        const pathStyle = this.pathStyle(column);
+
+        const areaGenerator = area()
+            .curve(curves[this.props.interpolation])
+            .x(d => d.x0)
+            .y0(d => d.y0)
+            .y1(d => d.y1);
+
+        // Use the area generation function with our stacked data
+        // to get an SVG path
+        const areaPath = areaGenerator(data);
+
+        // Outline the top of the curve
+        const lineGenerator = line()
+            .curve(curves[this.props.interpolation])
+            .x(d => d.x0)
+            .y(d => d.y1);
+        const outlinePath = lineGenerator(data);
+
+        return (
+            <g key={`area-${key}`}>
+                <path d={areaPath} style={style} />
+                <path
+                    d={areaPath}
+                    style={style}
+                    onClick={e => this.handleClick(e, column)}
+                    onMouseLeave={() => this.handleHoverLeave()}
+                    onMouseMove={e => this.handleHover(e, column)}
+                />
+                <path
+                    d={outlinePath}
+                    style={pathStyle}
+                    onClick={e => this.handleClick(e, column)}
+                    onMouseLeave={() => this.handleHoverLeave()}
+                    onMouseMove={e => this.handleHover(e, column)}
+                />
+            </g>
+        );
+    }
+
     renderPaths(columnList, direction) {
         const dir = direction === "up" ? 1 : -1;
         const size = this.props.series.size();
         const offsets = new Array(size).fill(0);
 
         return columnList.map((column, i) => {
-            const style = this.areaStyle(column);
-            const pathStyle = this.pathStyle(column);
-
             // Stack the series columns to get our data in x0, y0, y1 format
-            const data = [];
-            for (let j = 0; j < this.props.series.size(); j += 1) {
-                const seriesPoint = this.props.series.at(j);
-                data.push({
-                    x0: this.props.timeScale(seriesPoint.timestamp()),
-                    y0: this.props.yScale(offsets[j]),
-                    y1: this.props.yScale(offsets[j] + dir * seriesPoint.get(column))
-                });
-                if (this.props.stack) {
-                    offsets[j] += dir * seriesPoint.get(column);
+            const pathAreas = [];
+            let count = 1;
+            if (this.props.breakArea) {
+                // Remove nulls and NaNs from the area chart by generating a break in the area chart
+                let currentPoints = null;
+                for (let j = 0; j < this.props.series.size(); j += 1) {
+                    const seriesPoint = this.props.series.at(j);
+                    const value = seriesPoint.get(column);
+                    const badPoint = _.isNull(value) || _.isNaN(value) || !_.isFinite(value);
+                    if (!badPoint) {
+                        if (!currentPoints) currentPoints = [];
+                        currentPoints.push({
+                            x0: this.props.timeScale(seriesPoint.timestamp()),
+                            y0: this.props.yScale(offsets[j]),
+                            y1: this.props.yScale(offsets[j] + dir * seriesPoint.get(column))
+                        });
+                        if (this.props.stack) {
+                            offsets[j] += dir * seriesPoint.get(column);
+                        }
+                    } else if (currentPoints) {
+                        if (currentPoints.length > 1) {
+                            pathAreas.push(this.renderArea(currentPoints, column, count));
+                            count += 1;
+                        }
+                        currentPoints = null;
+                    }
                 }
+                if (currentPoints && currentPoints.length > 1) {
+                    pathAreas.push(this.renderArea(currentPoints, column, count));
+                    count += 1;
+                }
+            } else {
+                // Ignore nulls and NaNs in the area chart
+                const cleanedPoints = [];
+                for (let j = 0; j < this.props.series.size(); j += 1) {
+                    const seriesPoint = this.props.series.at(j);
+                    const value = seriesPoint.get(column);
+                    const badPoint = _.isNull(value) || _.isNaN(value) || !_.isFinite(value);
+                    if (!badPoint) {
+                        cleanedPoints.push({
+                            x0: this.props.timeScale(seriesPoint.timestamp()),
+                            y0: this.props.yScale(offsets[j]),
+                            y1: this.props.yScale(offsets[j] + dir * seriesPoint.get(column))
+                        });
+                        if (this.props.stack) {
+                            offsets[j] += dir * seriesPoint.get(column);
+                        }
+                    }
+                }
+
+                pathAreas.push(this.renderArea(cleanedPoints, column, count));
+                count += 1;
             }
 
-            // Use D3 to build an area generation function
-            const areaGenerator = area()
-                .curve(curves[this.props.interpolation])
-                .x(d => d.x0)
-                .y0(d => d.y0)
-                .y1(d => d.y1);
-
-            // Use the area generation function with our stacked data
-            // to get an SVG path
-            const areaPath = areaGenerator(data);
-
-            // Outline the top of the curve
-            const lineGenerator = line()
-                .curve(curves[this.props.interpolation])
-                .x(d => d.x0)
-                .y(d => d.y1);
-            const outlinePath = lineGenerator(data);
-
-            return (
-                <g key={`area-${i}`}>
-                    <path
-                        d={areaPath}
-                        style={style}
-                        onClick={e => this.handleClick(e, column)}
-                        onMouseLeave={() => this.handleHoverLeave()}
-                        onMouseMove={e => this.handleHover(e, column)}
-                    />
-                    <path
-                        d={outlinePath}
-                        style={pathStyle}
-                        onClick={e => this.handleClick(e, column)}
-                        onMouseLeave={() => this.handleHoverLeave()}
-                        onMouseMove={e => this.handleHover(e, column)}
-                    />
-                </g>
-            );
+            return <g key={column}>{pathAreas}</g>;
         });
     }
 
@@ -440,7 +486,16 @@ AreaChart.propTypes = {
     /**
      * [Internal] The width supplied by the surrounding ChartContainer
      */
-    width: PropTypes.number
+    width: PropTypes.number,
+
+    /**
+     * The determines how to handle bad/missing values in the supplied
+     * TimeSeries. A missing value can be null or NaN. If breakArea
+     * is set to true then the area chart will be broken on either side of
+     * the bad value(s). If breakArea is false (the default) bad values
+     * are simply removed and the adjoining points are connected.
+     */
+    breakArea: PropTypes.bool
 };
 
 AreaChart.defaultProps = {
@@ -450,5 +505,6 @@ AreaChart.defaultProps = {
         up: ["value"],
         down: []
     },
-    stack: true
+    stack: true,
+    breakArea: true
 };


### PR DESCRIPTION
Adds feature for #242 : Show data gaps in AreaCharts using breakArea={true} prop

<img width="1397" alt="screen shot 2018-04-27 at 12 57 22 am" src="https://user-images.githubusercontent.com/5708022/39351577-cfdd16ac-49b6-11e8-836e-f2f6b48751e5.png">
