### PR TITLE
Fixes #261

### DIFF
--- a/lib/components/AreaChart.js
+++ b/lib/components/AreaChart.js
@@ -445,10 +445,9 @@ var AreaChart = (function(_React$Component) {
                                 if (_this3.props.stack) {
                                     offsets[j] += dir * seriesPoint.get(column);
                                 }
-                            }
-                            // Case Two
-                            // When only one area chart is to be drawn, then create different areas for each area and ignore nulls and NaNs
-                            else {
+                            } else {
+                                // Case Two
+                                // When only one area chart is to be drawn, then create different areas for each area and ignore nulls and NaNs
                                 if (!badPoint) {
                                     if (!currentPoints) currentPoints = [];
                                     currentPoints.push({

--- a/lib/components/ChartRow.js
+++ b/lib/components/ChartRow.js
@@ -315,7 +315,7 @@ var ChartRow = (function(_React$Component) {
                         if (_this3.isChildYAxis(child)) {
                             var yaxis = child;
 
-                            if (yaxis.props.id) {
+                            if (yaxis.props.id && yaxis.props.visible !== false) {
                                 // Relate id to the axis
                                 yAxisMap[yaxis.props.id] = yaxis;
                             }
@@ -370,26 +370,28 @@ var ChartRow = (function(_React$Component) {
                     posx -= colWidth;
                     if (colWidth > 0 && leftColumnIndex < leftAxisList.length) {
                         id = leftAxisList[leftColumnIndex];
-                        transform = "translate(" + (posx + paddingLeft) + ",0)";
+                        if (_underscore2.default.has(yAxisMap, id)) {
+                            transform = "translate(" + (posx + paddingLeft) + ",0)";
 
-                        // Additional props for left aligned axes
-                        props = {
-                            width: colWidth,
-                            height: innerHeight,
-                            align: "left",
-                            scale: this.scaleMap[id].latestScale()
-                        };
+                            // Additional props for left aligned axes
+                            props = {
+                                width: colWidth,
+                                height: innerHeight,
+                                align: "left",
+                                scale: this.scaleMap[id].latestScale()
+                            };
 
-                        // Cloned left axis
-                        axis = _react2.default.cloneElement(yAxisMap[id], props);
+                            // Cloned left axis
+                            axis = _react2.default.cloneElement(yAxisMap[id], props);
 
-                        axes.push(
-                            _react2.default.createElement(
-                                "g",
-                                { key: "y-axis-left-" + leftColumnIndex, transform: transform },
-                                axis
-                            )
-                        );
+                            axes.push(
+                                _react2.default.createElement(
+                                    "g",
+                                    { key: "y-axis-left-" + leftColumnIndex, transform: transform },
+                                    axis
+                                )
+                            );
+                        }
                     }
                 }
 
@@ -402,26 +404,31 @@ var ChartRow = (function(_React$Component) {
                     var _colWidth = this.props.rightAxisWidths[rightColumnIndex];
                     if (_colWidth > 0 && rightColumnIndex < rightAxisList.length) {
                         id = rightAxisList[rightColumnIndex];
-                        transform = "translate(" + (posx + paddingLeft) + ",0)";
+                        if (_underscore2.default.has(yAxisMap, id)) {
+                            transform = "translate(" + (posx + paddingLeft) + ",0)";
 
-                        // Additional props for right aligned axes
-                        props = {
-                            width: _colWidth,
-                            height: innerHeight,
-                            align: "right",
-                            scale: this.scaleMap[id].latestScale()
-                        };
+                            // Additional props for right aligned axes
+                            props = {
+                                width: _colWidth,
+                                height: innerHeight,
+                                align: "right",
+                                scale: this.scaleMap[id].latestScale()
+                            };
 
-                        // Cloned right axis
-                        axis = _react2.default.cloneElement(yAxisMap[id], props);
+                            // Cloned right axis
+                            axis = _react2.default.cloneElement(yAxisMap[id], props);
 
-                        axes.push(
-                            _react2.default.createElement(
-                                "g",
-                                { key: "y-axis-right-" + rightColumnIndex, transform: transform },
-                                axis
-                            )
-                        );
+                            axes.push(
+                                _react2.default.createElement(
+                                    "g",
+                                    {
+                                        key: "y-axis-right-" + rightColumnIndex,
+                                        transform: transform
+                                    },
+                                    axis
+                                )
+                            );
+                        }
                     }
 
                     posx += _colWidth;

--- a/src/components/ChartRow.js
+++ b/src/components/ChartRow.js
@@ -191,7 +191,7 @@ export default class ChartRow extends React.Component {
                 if (this.isChildYAxis(child)) {
                     const yaxis = child;
 
-                    if (yaxis.props.id) {
+                    if (yaxis.props.id && yaxis.props.visible !== false) {
                         // Relate id to the axis
                         yAxisMap[yaxis.props.id] = yaxis;
                     }
@@ -234,24 +234,26 @@ export default class ChartRow extends React.Component {
             posx -= colWidth;
             if (colWidth > 0 && leftColumnIndex < leftAxisList.length) {
                 id = leftAxisList[leftColumnIndex];
-                transform = `translate(${posx + paddingLeft},0)`;
+                if (_.has(yAxisMap, id)) {
+                    transform = `translate(${posx + paddingLeft},0)`;
 
-                // Additional props for left aligned axes
-                props = {
-                    width: colWidth,
-                    height: innerHeight,
-                    align: "left",
-                    scale: this.scaleMap[id].latestScale()
-                };
+                    // Additional props for left aligned axes
+                    props = {
+                        width: colWidth,
+                        height: innerHeight,
+                        align: "left",
+                        scale: this.scaleMap[id].latestScale()
+                    };
 
-                // Cloned left axis
-                axis = React.cloneElement(yAxisMap[id], props);
+                    // Cloned left axis
+                    axis = React.cloneElement(yAxisMap[id], props);
 
-                axes.push(
-                    <g key={`y-axis-left-${leftColumnIndex}`} transform={transform}>
-                        {axis}
-                    </g>
-                );
+                    axes.push(
+                        <g key={`y-axis-left-${leftColumnIndex}`} transform={transform}>
+                            {axis}
+                        </g>
+                    );
+                }
             }
         }
 
@@ -264,24 +266,26 @@ export default class ChartRow extends React.Component {
             const colWidth = this.props.rightAxisWidths[rightColumnIndex];
             if (colWidth > 0 && rightColumnIndex < rightAxisList.length) {
                 id = rightAxisList[rightColumnIndex];
-                transform = `translate(${posx + paddingLeft},0)`;
+                if (_.has(yAxisMap, id)) {
+                    transform = `translate(${posx + paddingLeft},0)`;
 
-                // Additional props for right aligned axes
-                props = {
-                    width: colWidth,
-                    height: innerHeight,
-                    align: "right",
-                    scale: this.scaleMap[id].latestScale()
-                };
+                    // Additional props for right aligned axes
+                    props = {
+                        width: colWidth,
+                        height: innerHeight,
+                        align: "right",
+                        scale: this.scaleMap[id].latestScale()
+                    };
 
-                // Cloned right axis
-                axis = React.cloneElement(yAxisMap[id], props);
+                    // Cloned right axis
+                    axis = React.cloneElement(yAxisMap[id], props);
 
-                axes.push(
-                    <g key={`y-axis-right-${rightColumnIndex}`} transform={transform}>
-                        {axis}
-                    </g>
-                );
+                    axes.push(
+                        <g key={`y-axis-right-${rightColumnIndex}`} transform={transform}>
+                            {axis}
+                        </g>
+                    );
+                }
             }
 
             posx += colWidth;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2415,6 +2415,10 @@ dom-urls@^1.1.0:
   dependencies:
     urijs "^1.16.1"
 
+dom-walk@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/dom-walk/-/dom-walk-0.1.1.tgz#672226dc74c8f799ad35307df936aba11acd6018"
+
 domain-browser@^1.1.1:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.1.7.tgz#867aa4b093faa05f1de08c06f4d7b21fdf8698bc"
@@ -3053,7 +3057,7 @@ fast-deep-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz#96256a3bc975595eb36d82e9929d060d893439ff"
 
-fast-levenshtein@~2.0.4:
+fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
 
@@ -3397,6 +3401,13 @@ global-prefix@^1.0.1:
     is-windows "^1.0.1"
     which "^1.2.14"
 
+global@^4.3.0:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/global/-/global-4.3.2.tgz#e76989268a6c74c38908b1305b10fc0e394e9d0f"
+  dependencies:
+    min-document "^2.19.0"
+    process "~0.5.1"
+
 globals@^9.0.0, globals@^9.17.0, globals@^9.18.0:
   version "9.18.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
@@ -3559,6 +3570,10 @@ hoek@2.x.x:
 hoist-non-react-statics@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz#aa448cf0986d55cc40773b17174b7dd066cb7cfb"
+
+hoist-non-react-statics@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.0.tgz#d2ca2dfc19c5a91c5a6615ce8e564ef0347e2a40"
 
 home-or-tmp@^2.0.0:
   version "2.0.0"
@@ -4873,6 +4888,12 @@ mimic-fn@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.1.0.tgz#e667783d92e89dbd342818b5230b9d62a672ad18"
 
+min-document@^2.19.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/min-document/-/min-document-2.19.0.tgz#7bd282e3f5842ed295bb748cdd9f1ffa2c824685"
+  dependencies:
+    dom-walk "^0.1.0"
+
 minimalistic-assert@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz#702be2dda6b37f4836bcb3f5db56641b64a1d3d3"
@@ -5796,6 +5817,10 @@ process@^0.11.0:
   version "0.11.10"
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
 
+process@~0.5.1:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/process/-/process-0.5.2.tgz#1638d8a8e34c2f440a91db95ab9aeb677fc185cf"
+
 progress@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
@@ -5826,6 +5851,14 @@ prop-types@^15.5.10:
   dependencies:
     fbjs "^0.8.9"
     loose-envify "^1.3.1"
+
+prop-types@^15.6.1:
+  version "15.6.1"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.1.tgz#36644453564255ddda391191fb3a125cbdf654ca"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
 
 proxy-addr@~1.1.4:
   version "1.1.4"
@@ -5975,11 +6008,26 @@ react-error-overlay@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-3.0.0.tgz#c2bc8f4d91f1375b3dad6d75265d51cd5eeaf655"
 
+react-hot-loader@4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/react-hot-loader/-/react-hot-loader-4.1.2.tgz#5e8025f5bc5605506586b46eb2c6cc4006fd54d7"
+  dependencies:
+    fast-levenshtein "^2.0.6"
+    global "^4.3.0"
+    hoist-non-react-statics "^2.5.0"
+    prop-types "^15.6.1"
+    react-lifecycles-compat "^3.0.2"
+    shallowequal "^1.0.2"
+
 react-input-autosize@^2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/react-input-autosize/-/react-input-autosize-2.1.2.tgz#a3dc11a5517c434db25229925541309de3f7a8f5"
   dependencies:
     prop-types "^15.5.8"
+
+react-lifecycles-compat@^3.0.2:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.3.tgz#473820154732f1ccd762e89324abab154255da6b"
 
 react-markdown@^2.4.4:
   version "2.5.0"
@@ -6531,6 +6579,10 @@ sha.js@^2.4.0, sha.js@^2.4.8:
   resolved "https://registry.yarnpkg.com/sha.js/-/sha.js-2.4.8.tgz#37068c2c476b6baf402d14a49c67f597921f634f"
   dependencies:
     inherits "^2.0.1"
+
+shallowequal@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.0.2.tgz#1561dbdefb8c01408100319085764da3fcf83f8f"
 
 shebang-command@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
Fixes #261 

The previous logic added a 0 width for hidden YAxis into the widths being passed to the ChartRow. This was then used to exclude the axis from the layout. However, if there was more than one row the width passed in would be derived from axes in the other rows so this logic would fail.

This adds an additional check for the visible prop set on the YAxis which excludes it from the map of ids to YAxis. That exclusion is then used to omit the axis itself from the render but still keep its scale etc.