### PR TITLE
Change the fraction of the chart at which to flip the event marker

### DIFF
--- a/src/components/EventMarker.js
+++ b/src/components/EventMarker.js
@@ -272,7 +272,7 @@ export default class EventMarker extends React.Component {
                 </g>
             );
         } else {
-            if (posx + 10 + w < this.props.width * 3 / 4) {
+            if (posx + 10 + w < this.props.width * 99/100) {
                 if (info) {
                     verticalStem = (
                         <line


### PR DESCRIPTION
Hello!

I have a very small PR to address an issue I've been seeing with event markers on really small charts.

If the width of the info box (`w`) is close to the width of the chart (`this.props.width`), it seemed the flipping of the event marker from the right side of the dot to the left side of the dot was happening too early.

This would cause clipping when the cursor was very near the left edge of the chart.

I've increased how close to the end of the chart the x position must be in order to flip the event marker. This means that esthetically, the marker swaps directions later, but still gives a tiny buffer at the end before it swaps (1% of the chart width, before it was 25%)

Here's a screenshot of the Climate temperature data example, when squished down pretty small:

Before:
<img width="363" alt="screen shot 2018-06-07 at 12 09 33 pm" src="https://user-images.githubusercontent.com/1816948/41114622-f5a2b57e-6a52-11e8-953a-b8d1909caa85.png">

After:
<img width="324" alt="screen shot 2018-06-07 at 12 58 01 pm" src="https://user-images.githubusercontent.com/1816948/41114647-04f7c3a2-6a53-11e8-86ae-1fbdff6400c2.png">

Let me know if there are additional things you need in the PR, and I can add them.

PS: I ran `npm run build` and it changed a lot of unrelated files. I elected to not include them in the PR.