### PR TITLE
YAxis looses format property on update

### DIFF
--- a/src/components/YAxis.js
+++ b/src/components/YAxis.js
@@ -124,7 +124,7 @@ export default class YAxis extends React.Component {
             height,
             chartExtent,
             absolute,
-            fmt,
+            format,
             type,
             showGrid,
             hideAxisLine
@@ -141,10 +141,10 @@ export default class YAxis extends React.Component {
                 hideAxisLine,
                 absolute,
                 type,
-                fmt
+                format
             );
         } else if (
-            this.props.fmt !== fmt ||
+            this.props.format !== format ||
             this.props.align !== align ||
             this.props.width !== width ||
             this.props.height !== height ||
@@ -164,7 +164,7 @@ export default class YAxis extends React.Component {
                 hideAxisLine,
                 absolute,
                 type,
-                fmt
+                format
             );
         }
     }


### PR DESCRIPTION
The name of the property is format, not fmt.
This resulted in the axis formatting defaulting to plain string instead of using the custom format provided when resizing or updating the axis in any way