### PR TITLE
Resizable Memory leak

### DIFF
--- a/src/components/Resizable.js
+++ b/src/components/Resizable.js
@@ -23,12 +23,12 @@ export default class Resizable extends React.Component {
     }
 
     componentDidMount() {
-        window.addEventListener("resize", () => this.handleResize());
+        window.addEventListener("resize", this.handleResize);
         this.handleResize();
     }
 
     componentWillUnmount() {
-        window.removeEventListener("resize", () => this.handleResize());
+        window.removeEventListener("resize", this.handleResize);
     }
 
     handleResize() {


### PR DESCRIPTION
Using anonymous functions prevented proper unsubscription from listening to events, which was a memory leak. Passing function reference fixes this problem

fix presented in #282 by @NightRare 👍 