### PR TITLE
Fix #284 - only increment stacking offset for good data points

### DIFF
--- a/src/components/AreaChart.js
+++ b/src/components/AreaChart.js
@@ -298,15 +298,15 @@ export default class AreaChart extends React.Component {
                                 y0: this.props.yScale(offsets[j]),
                                 y1: this.props.yScale(offsets[j] + dir * seriesPoint.get(column))
                             });
+                            if (this.props.stack) {
+                                offsets[j] += dir * seriesPoint.get(column);
+                            }
                         } else {
                             currentPoints.push({
                                 x0: this.props.timeScale(seriesPoint.timestamp()),
                                 y0: this.props.yScale(offsets[j]),
                                 y1: this.props.yScale(offsets[j])
                             });
-                        }
-                        if (this.props.stack) {
-                            offsets[j] += dir * seriesPoint.get(column);
                         }
                     }
                     // Case Two


### PR DESCRIPTION
This fixes #284 by only incrementing the stacking offset for a given column at the given time when there is valid data for that column at that time. Since the value is treated as 0 when the value is missing or invalid, there is no need to modify the stacking offset in the `badPoint` branch.

As a side note/question: is there a reason you repeatedly call `seriesPoint.get(column)` even though you've already retrieved this value and stored it in `const value`? 

It seems like the logic would be a lot simpler to simply set `value` to `0` when it is considered "bad", which would remove the need for a lot of the follow-on conditionals (plus, you'd remove the overhead of the repeated method call and data lookup in Immutable.js).

Without unit tests, I'm a little hesitant to make a refactoring like that in a codebase I'm not particularly familiar with, so I went with the smaller change to fix the bug.