### PR TITLE
Closes #297 - allow disabling mousewheel zoom

### DIFF
--- a/src/components/ChartContainer.js
+++ b/src/components/ChartContainer.js
@@ -63,6 +63,35 @@ const defaultTitleStyle = {
  * ```
  */
 export default class ChartContainer extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.state = this.getStateFromProps(props);
+    }
+
+    getStateFromProps(props) {
+        const state = {};
+        if (props.enablePanZoom) {
+            state.enablePanZoom = true;
+            state.enableDragPan =
+                typeof props.enableDragPan === "undefined" ? true : props.enableDragPan;
+            state.enableWheelZoom =
+                typeof props.enableWheelZoom === "undefined" ? true : props.enableWheelZoom;
+        } else if (props.enableDragZoom) {
+            state.enableDragZoom = true;
+            state.enableWheelZoom =
+                typeof props.enableWheelZoom === "undefined" ? true : props.enableWheelZoom;
+        } else {
+            state.enableDragPan = props.enableDragPan;
+            state.enableWheelZoom = props.enableWheelZoom;
+        }
+        return state;
+    }
+
+    componentWillReceiveProps(nextProps) {
+        this.setState(this.getStateFromProps(nextProps));
+    }
+
     //
     // Event handlers
     //
@@ -279,7 +308,7 @@ export default class ChartContainer extends React.Component {
                     minTime: this.props.minTime,
                     maxTime: this.props.maxTime,
                     transition: this.props.transition,
-                    enablePanZoom: this.props.enablePanZoom,
+                    enablePanZoom: this.state.enablePanZoom,
                     minDuration: this.props.minDuration,
                     showGrid: this.props.showGrid,
                     timeFormat: this.props.format,
@@ -379,8 +408,10 @@ export default class ChartContainer extends React.Component {
                     width={chartsWidth}
                     height={chartsHeight + timeAxisHeight}
                     scale={timeScale}
-                    enablePanZoom={this.props.enablePanZoom}
-                    enableDragZoom={this.props.enableDragZoom}
+                    enableDragPan={this.state.enableDragPan}
+                    enableDragZoom={this.state.enableDragZoom}
+                    enablePanZoom={this.state.enablePanZoom}
+                    enableWheelZoom={this.state.enableWheelZoom}
                     minDuration={this.props.minDuration}
                     minTime={this.props.minTime}
                     maxTime={this.props.maxTime}
@@ -480,14 +511,24 @@ ChartContainer.propTypes = {
     maxTime: PropTypes.instanceOf(Date),
 
     /**
-     * Boolean to turn on interactive pan and zoom behavior for the chart.
+     * Boolean to turn on interactive drag to pan behavior for the chart.
      */
-    enablePanZoom: PropTypes.bool,
+    enableDragPan: PropTypes.bool,
 
     /**
      * Boolean to turn on interactive drag to zoom behavior for the chart.
      */
     enableDragZoom: PropTypes.bool,
+
+    /**
+     * Boolean to turn on interactive pan and mousewheel zoom behavior for the chart.
+     */
+    enablePanZoom: PropTypes.bool,
+
+    /**
+     * Boolean to turn on interactive mousewheel zoom behavior for the chart.
+     */
+    enableWheelZoom: PropTypes.bool,
 
     /**
      * If this is set the timerange of the chart cannot be zoomed in further
@@ -647,8 +688,10 @@ ChartContainer.propTypes = {
 ChartContainer.defaultProps = {
     width: 800,
     padding: 0,
-    enablePanZoom: false,
+    enableDragPan: false,
     enableDragZoom: false,
+    enablePanZoom: false,
+    enableWheelZoom: false,
     utc: false,
     showGrid: false,
     showGridPosition: "over",

--- a/src/components/EventHandler.js
+++ b/src/components/EventHandler.js
@@ -55,7 +55,7 @@ export default class EventHandler extends React.Component {
     //
 
     handleScrollWheel(e) {
-        if (!this.props.enablePanZoom && !this.props.enableDragZoom) {
+        if (!this.props.enableWheelZoom) {
             return;
         }
 
@@ -119,7 +119,7 @@ export default class EventHandler extends React.Component {
     }
 
     handleMouseDown(e) {
-        if (!this.props.enablePanZoom && !this.props.enableDragZoom) {
+        if (!this.props.enableDragPan && !this.props.enableDragZoom) {
             return;
         }
 
@@ -137,7 +137,7 @@ export default class EventHandler extends React.Component {
             });
         }
 
-        if (this.props.enablePanZoom) {
+        if (this.props.enableDragPan) {
             const x = e.pageX;
             const y = e.pageY;
             const xy0 = [Math.round(x), Math.round(y)];
@@ -157,7 +157,7 @@ export default class EventHandler extends React.Component {
     }
 
     handleMouseUp(e) {
-        if (!this.props.onMouseClick && !this.props.enablePanZoom && !this.props.enableDragZoom) {
+        if (!this.props.onMouseClick && !this.props.enableDragPan && !this.props.enableDragZoom) {
             return;
         }
 
@@ -208,7 +208,7 @@ export default class EventHandler extends React.Component {
             });
         }
 
-        if (this.props.enablePanZoom) {
+        if (this.props.enableDragPan) {
             this.setState({
                 isPanning: false,
                 initialPanBegin: null,
@@ -312,8 +312,10 @@ export default class EventHandler extends React.Component {
 
 EventHandler.propTypes = {
     children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]),
-    enablePanZoom: PropTypes.bool,
+    enableDragPan: PropTypes.bool,
     enableDragZoom: PropTypes.bool,
+    enableWheelZoom: PropTypes.bool,
+    enablePanZoom: PropTypes.bool,
     scale: PropTypes.func.isRequired,
     width: PropTypes.number.isRequired,
     height: PropTypes.number.isRequired,
@@ -327,6 +329,8 @@ EventHandler.propTypes = {
 };
 
 EventHandler.defaultProps = {
-    enablePanZoom: false,
-    enableDragZoom: false
+    enableDragPan: false,
+    enableDragZoom: false,
+    enableWheelZoom: false,
+    enablePanZoom: false
 };

--- a/src/website/packages/charts/examples/currency/Index.js
+++ b/src/website/packages/charts/examples/currency/Index.js
@@ -138,7 +138,8 @@ class currency extends React.Component {
                                 timeAxisHeight={65}
                                 onTrackerChanged={this.handleTrackerChanged}
                                 onBackgroundClick={() => this.setState({ selection: null })}
-                                enablePanZoom={true}
+                                enableWheelZoom={true}
+                                enableDragPan={true}
                                 onTimeRangeChanged={this.handleTimeRangeChange}
                                 onMouseMove={(x, y) => this.handleMouseMove(x, y)}
                                 minDuration={1000 * 60 * 60 * 24 * 30}


### PR DESCRIPTION
This is a non-breaking version that uses `enablePanZoom` to set the other properties. New usage in currency example, and other examples still working with enablePanZoom.

A breaking version could discard all the new state junk in ChartContainer and get rid of the `enablePanZoom` prop.