### PR TITLE
Removed flexbox-react dependency (issue #310)

### DIFF
--- a/lib/components/Legend.js
+++ b/lib/components/Legend.js
@@ -37,10 +37,6 @@ var _propTypes = require("prop-types");
 
 var _propTypes2 = _interopRequireDefault(_propTypes);
 
-var _flexboxReact = require("flexbox-react");
-
-var _flexboxReact2 = _interopRequireDefault(_flexboxReact);
-
 var _styler = require("../js/styler");
 
 function _interopRequireDefault(obj) {
@@ -339,50 +335,50 @@ var LegendItem = (function(_React$Component) {
                 //       The alternative it to put it on a <a> or something?
 
                 return _react2.default.createElement(
-                    _flexboxReact2.default,
-                    { flexDirection: "column", key: itemKey },
+                    "div",
+                    {
+                        style: {
+                            display: "flex",
+                            flexDirection: "column"
+                        },
+                        key: itemKey,
+                        onClick: function onClick(e) {
+                            return _this2.handleClick(e, itemKey);
+                        },
+                        onMouseMove: function onMouseMove(e) {
+                            return _this2.handleHover(e, itemKey);
+                        },
+                        onMouseLeave: function onMouseLeave() {
+                            return _this2.handleHoverLeave();
+                        }
+                    },
                     _react2.default.createElement(
                         "div",
                         {
-                            onClick: function onClick(e) {
-                                return _this2.handleClick(e, itemKey);
-                            },
-                            onMouseMove: function onMouseMove(e) {
-                                return _this2.handleHover(e, itemKey);
-                            },
-                            onMouseLeave: function onMouseLeave() {
-                                return _this2.handleHoverLeave();
+                            style: {
+                                display: "flex",
+                                flexDirection: "row",
+                                alignItems: "center"
                             }
                         },
+                        _react2.default.createElement("div", { style: { width: "20px" } }, symbol),
                         _react2.default.createElement(
-                            _flexboxReact2.default,
-                            { flexDirection: "row" },
+                            "div",
+                            {
+                                style: {
+                                    display: "flex",
+                                    flexDirection: "column"
+                                }
+                            },
                             _react2.default.createElement(
-                                _flexboxReact2.default,
-                                { width: "20px" },
-                                symbol
+                                "div",
+                                { style: labelStyle },
+                                this.props.label
                             ),
                             _react2.default.createElement(
-                                _flexboxReact2.default,
-                                { flexDirection: "column" },
-                                _react2.default.createElement(
-                                    _flexboxReact2.default,
-                                    null,
-                                    _react2.default.createElement(
-                                        "div",
-                                        { style: labelStyle },
-                                        this.props.label
-                                    )
-                                ),
-                                _react2.default.createElement(
-                                    _flexboxReact2.default,
-                                    null,
-                                    _react2.default.createElement(
-                                        "div",
-                                        { style: valueStyle },
-                                        this.props.value
-                                    )
-                                )
+                                "div",
+                                { style: valueStyle },
+                                this.props.value
                             )
                         )
                     )
@@ -567,7 +563,7 @@ var Legend = (function(_React$Component2) {
 
                 if (this.props.stack) {
                     return _react2.default.createElement(
-                        _flexboxReact2.default,
+                        Flexbox,
                         {
                             justifyContent: align,
                             flexDirection: "column",
@@ -577,7 +573,7 @@ var Legend = (function(_React$Component2) {
                     );
                 } else {
                     return _react2.default.createElement(
-                        _flexboxReact2.default,
+                        Flexbox,
                         {
                             justifyContent: align,
                             flexWrap: "wrap",

--- a/lib/components/Legend.js
+++ b/lib/components/Legend.js
@@ -563,21 +563,26 @@ var Legend = (function(_React$Component2) {
 
                 if (this.props.stack) {
                     return _react2.default.createElement(
-                        Flexbox,
+                        "div",
                         {
-                            justifyContent: align,
-                            flexDirection: "column",
-                            marginBottom: this.props.marginBottom
+                            style: {
+                                display: "flex",
+                                justifyContent: align,
+                                flexDirection: "column",
+                                marginBottom: this.props.marginBottom
+                            }
                         },
                         items
                     );
                 } else {
                     return _react2.default.createElement(
-                        Flexbox,
+                        "div",
                         {
-                            justifyContent: align,
-                            flexWrap: "wrap",
-                            marginBottom: this.props.marginBottom
+                            style: {
+                                justifyContent: align,
+                                flexWrap: "wrap",
+                                marginBottom: this.props.marginBottom
+                            }
                         },
                         items
                     );
@@ -675,8 +680,7 @@ Legend.propTypes = {
     stack: _propTypes2.default.bool,
 
     /**
-     * The margin at the bottom passed to the FlexBox component
-     * Default value is 20px
+     * The margin at the bottom. Default value is 20px
      */
     marginBottom: _propTypes2.default.string
 };

--- a/lib/components/Legend.js
+++ b/lib/components/Legend.js
@@ -579,6 +579,7 @@ var Legend = (function(_React$Component2) {
                         "div",
                         {
                             style: {
+                                display: "flex",
                                 justifyContent: align,
                                 flexWrap: "wrap",
                                 marginBottom: this.props.marginBottom

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,21 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@types/react": {
-      "version": "15.6.15",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-15.6.15.tgz",
-      "integrity": "sha512-LOHbyeKRNYLEotniN3DlRGrpXorXupvFSbKrNzc9dZ87uL+IJDbGYVerxKaG1jbnhuc7RhEWxlNmUVtYm3mtNg==",
-      "optional": true
-    },
-    "@types/react-dom": {
-      "version": "0.14.23",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-0.14.23.tgz",
-      "integrity": "sha1-zs/PrXVLTCdl/l0puBswGImtbC4=",
-      "optional": true,
-      "requires": {
-        "@types/react": "*"
-      }
-    },
     "abab": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
@@ -1630,7 +1615,8 @@
     "base64-js": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
-      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
+      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
+      "dev": true
     },
     "batch": {
       "version": "0.6.1",
@@ -1913,15 +1899,6 @@
       "dev": true,
       "requires": {
         "node-int64": "^0.4.0"
-      }
-    },
-    "buffer": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.1.0.tgz",
-      "integrity": "sha512-YkIRgwsZwJWTnyQrsBTWefizHh+8GYj3kbL1BTiAQ/9pwpino0G7B2gp5tx/FUBqUlvtxV85KNR3mwfAtv15Yw==",
-      "requires": {
-        "base64-js": "^1.0.2",
-        "ieee754": "^1.1.4"
       }
     },
     "buffer-from": {
@@ -2698,11 +2675,6 @@
       "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
       "dev": true
     },
-    "css-color-keywords": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
-      "integrity": "sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU="
-    },
     "css-color-names": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
@@ -2790,16 +2762,6 @@
             "regjsparser": "^0.1.4"
           }
         }
-      }
-    },
-    "css-to-react-native": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-2.2.0.tgz",
-      "integrity": "sha512-SWG8+tsVRBHpxn1cSDmx7B95DJCiKwUecBbboGpm2znDCnJDMGkcoYR73w1p2IZMab6iNqVms8VC+4TrSqoFeQ==",
-      "requires": {
-        "css-color-keywords": "^1.0.0",
-        "fbjs": "^0.8.5",
-        "postcss-value-parser": "^3.3.0"
       }
     },
     "css-what": {
@@ -3390,8 +3352,7 @@
     "dom-walk": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
-      "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg=",
-      "dev": true
+      "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
     },
     "domain-browser": {
       "version": "1.2.0",
@@ -4290,8 +4251,7 @@
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-      "dev": true
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
     "fastparse": {
       "version": "1.1.1",
@@ -4505,16 +4465,6 @@
       "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
       "integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I=",
       "dev": true
-    },
-    "flexbox-react": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/flexbox-react/-/flexbox-react-4.4.0.tgz",
-      "integrity": "sha1-NevT6xCLvaGydg30loqrxwYfXzM=",
-      "requires": {
-        "@types/react": "^15.0.21",
-        "@types/react-dom": "^0.14.23",
-        "styled-components": "^2.0.0"
-      }
     },
     "follow-redirects": {
       "version": "1.5.0",
@@ -5229,7 +5179,6 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
       "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
-      "dev": true,
       "requires": {
         "min-document": "^2.19.0",
         "process": "~0.5.1"
@@ -5434,7 +5383,8 @@
     "has-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+      "dev": true
     },
     "has-value": {
       "version": "1.0.0",
@@ -5536,11 +5486,6 @@
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.1"
       }
-    },
-    "hoist-non-react-statics": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz",
-      "integrity": "sha1-qkSM8JhtVcxAdzsXF0t90GbLfPs="
     },
     "home-or-tmp": {
       "version": "2.0.0",
@@ -5803,7 +5748,8 @@
     "ieee754": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.11.tgz",
-      "integrity": "sha512-VhDzCKN7K8ufStx/CLj5/PDTMgph+qwN5Pkd5i0sGnVwk56zJ0lkT8Qzi1xqWLS0Wp29DgDtNeS7v8/wMoZeHg=="
+      "integrity": "sha512-VhDzCKN7K8ufStx/CLj5/PDTMgph+qwN5Pkd5i0sGnVwk56zJ0lkT8Qzi1xqWLS0Wp29DgDtNeS7v8/wMoZeHg==",
+      "dev": true
     },
     "ignore": {
       "version": "3.3.8",
@@ -6256,6 +6202,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
       "requires": {
         "isobject": "^3.0.1"
       }
@@ -6370,7 +6317,8 @@
     "isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "dev": true
     },
     "isomorphic-fetch": {
       "version": "2.2.1",
@@ -7662,7 +7610,6 @@
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
       "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
-      "dev": true,
       "requires": {
         "dom-walk": "^0.1.0"
       }
@@ -9397,7 +9344,8 @@
     "postcss-value-parser": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
-      "integrity": "sha1-h/OPnxj3dKSrTIojL1xc6IcqnRU="
+      "integrity": "sha1-h/OPnxj3dKSrTIojL1xc6IcqnRU=",
+      "dev": true
     },
     "postcss-zindex": {
       "version": "2.2.0",
@@ -9494,8 +9442,7 @@
     "process": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
-      "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8=",
-      "dev": true
+      "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
     },
     "process-nextick-args": {
       "version": "2.0.0",
@@ -9820,7 +9767,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-4.1.2.tgz",
       "integrity": "sha512-7EFwgpJOx4AG4pwVifgr/ZNBPAxl2z424nGJPc/APB3F8YtCA3WdYuGlcerRK2C9vYAoqiiLw745IB3wjnzrRQ==",
-      "dev": true,
       "requires": {
         "fast-levenshtein": "^2.0.6",
         "global": "^4.3.0",
@@ -9833,8 +9779,7 @@
         "hoist-non-react-statics": {
           "version": "2.5.0",
           "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.0.tgz",
-          "integrity": "sha512-6Bl6XsDT1ntE0lHbIhr4Kp2PGcleGZ66qu5Jqk8lc0Xc/IeG6gVLmwUGs/K0Us+L8VWoKgj0uWdPMataOsm31w==",
-          "dev": true
+          "integrity": "sha512-6Bl6XsDT1ntE0lHbIhr4Kp2PGcleGZ66qu5Jqk8lc0Xc/IeG6gVLmwUGs/K0Us+L8VWoKgj0uWdPMataOsm31w=="
         }
       }
     },
@@ -9850,8 +9795,7 @@
     "react-lifecycles-compat": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.3.tgz",
-      "integrity": "sha512-bOr65SSYgxDgDNqLnDqt+gropXGPNB1Wbyys4tOYiNuP/qYWC4qFM9XH1ruzq+tT6EjE29pJsCr19rclKtpUEg==",
-      "dev": true
+      "integrity": "sha512-bOr65SSYgxDgDNqLnDqt+gropXGPNB1Wbyys4tOYiNuP/qYWC4qFM9XH1ruzq+tT6EjE29pJsCr19rclKtpUEg=="
     },
     "react-markdown": {
       "version": "2.5.1",
@@ -10896,8 +10840,7 @@
     "shallowequal": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.0.2.tgz",
-      "integrity": "sha512-zlVXeVUKvo+HEv1e2KQF/csyeMKx2oHvatQ9l6XjCUj3agvC8XGf6R9HvIPDSmp8FNPvx7b5kaEJTRi7CqxtEw==",
-      "dev": true
+      "integrity": "sha512-zlVXeVUKvo+HEv1e2KQF/csyeMKx2oHvatQ9l6XjCUj3agvC8XGf6R9HvIPDSmp8FNPvx7b5kaEJTRi7CqxtEw=="
     },
     "shebang-command": {
       "version": "1.2.0",
@@ -11415,30 +11358,11 @@
         }
       }
     },
-    "styled-components": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-2.4.0.tgz",
-      "integrity": "sha512-bLW0/lQxTgJ0y+TEllctly+/B0Hz2N82e5AhubP+FIVPSisyOzyFnZzWdqRml7RDwRCsT+EGNN8YYa0VFutT+w==",
-      "requires": {
-        "buffer": "^5.0.3",
-        "css-to-react-native": "^2.0.3",
-        "fbjs": "^0.8.9",
-        "hoist-non-react-statics": "^1.2.0",
-        "is-plain-object": "^2.0.1",
-        "prop-types": "^15.5.4",
-        "stylis": "^3.4.0",
-        "supports-color": "^3.2.3"
-      }
-    },
-    "stylis": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/stylis/-/stylis-3.5.0.tgz",
-      "integrity": "sha512-pP7yXN6dwMzAR29Q0mBrabPCe0/mNO1MSr93bhay+hcZondvMMTpeGyd8nbhYJdyperNT2DRxONQuUGcJr5iPw=="
-    },
     "supports-color": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
       "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+      "dev": true,
       "requires": {
         "has-flag": "^1.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
         "d3-time-format": "^2.0.5",
         "d3-transition": "^1.1.0",
         "dom-resize": "^1.0.3",
-        "flexbox-react": "^4.3.3",
         "invariant": "^2.1.1",
         "merge": "^1.2.0",
         "moment": "^2.18.1",

--- a/src/components/Legend.js
+++ b/src/components/Legend.js
@@ -12,7 +12,6 @@ import _ from "underscore";
 import merge from "merge";
 import React from "react";
 import PropTypes from "prop-types";
-import Flexbox from "flexbox-react";
 
 import { Styler } from "../js/styler";
 
@@ -225,25 +224,35 @@ class LegendItem extends React.Component {
         //       The alternative it to put it on a <a> or something?
 
         return (
-            <Flexbox flexDirection="column" key={itemKey}>
+            <div
+                style={{
+                    display: "flex",
+                    flexDirection: "column"
+                }}
+                key={itemKey}
+                onClick={e => this.handleClick(e, itemKey)}
+                onMouseMove={e => this.handleHover(e, itemKey)}
+                onMouseLeave={() => this.handleHoverLeave()}
+            >
                 <div
-                    onClick={e => this.handleClick(e, itemKey)}
-                    onMouseMove={e => this.handleHover(e, itemKey)}
-                    onMouseLeave={() => this.handleHoverLeave()}
+                    style={{
+                        display: "flex",
+                        flexDirection: "row",
+                        alignItems: "center"
+                    }}
                 >
-                    <Flexbox flexDirection="row">
-                        <Flexbox width="20px">{symbol}</Flexbox>
-                        <Flexbox flexDirection="column">
-                            <Flexbox>
-                                <div style={labelStyle}>{this.props.label}</div>
-                            </Flexbox>
-                            <Flexbox>
-                                <div style={valueStyle}>{this.props.value}</div>
-                            </Flexbox>
-                        </Flexbox>
-                    </Flexbox>
+                    <div style={{ width: "20px" }}>{symbol}</div>
+                    <div
+                        style={{
+                            display: "flex",
+                            flexDirection: "column"
+                        }}
+                    >
+                        <div style={labelStyle}>{this.props.label}</div>
+                        <div style={valueStyle}>{this.props.value}</div>
+                    </div>
                 </div>
-            </Flexbox>
+            </div>
         );
     }
 }

--- a/src/components/Legend.js
+++ b/src/components/Legend.js
@@ -402,6 +402,7 @@ export default class Legend extends React.Component {
             return (
                 <div
                     style={{
+                        display: "flex",
                         justifyContent: align,
                         flexWrap: "wrap",
                         marginBottom: this.props.marginBottom

--- a/src/components/Legend.js
+++ b/src/components/Legend.js
@@ -387,23 +387,28 @@ export default class Legend extends React.Component {
 
         if (this.props.stack) {
             return (
-                <Flexbox
-                    justifyContent={align}
-                    flexDirection={"column"}
-                    marginBottom={this.props.marginBottom}
+                <div
+                    style={{
+                        display: "flex",
+                        justifyContent: align,
+                        flexDirection: "column",
+                        marginBottom: this.props.marginBottom
+                    }}
                 >
                     {items}
-                </Flexbox>
+                </div>
             );
         } else {
             return (
-                <Flexbox
-                    justifyContent={align}
-                    flexWrap={"wrap"}
-                    marginBottom={this.props.marginBottom}
+                <div
+                    style={{
+                        justifyContent: align,
+                        flexWrap: "wrap",
+                        marginBottom: this.props.marginBottom
+                    }}
                 >
                     {items}
-                </Flexbox>
+                </div>
             );
         }
     }
@@ -489,8 +494,7 @@ Legend.propTypes = {
     stack: PropTypes.bool,
 
     /**
-     * The margin at the bottom passed to the FlexBox component
-     * Default value is 20px
+     * The margin at the bottom. Default value is 20px
      */
     marginBottom: PropTypes.string
 };


### PR DESCRIPTION
I rewrote the return statement in Legend.js using simple divs and style tags to replace the Flexbox component from flexbox-react. (I also aligned the bullet symbols with their labels- they weren't quite vertically aligned with the text.)

(After "npm remove flexbox-react" and "npm run build", a bunch of other files changed because Babel likes to reformat the whitespace in its output with every release.)