### PR TITLE
Resizable properly binds this for handleResize() function

### DIFF
--- a/src/components/Resizable.js
+++ b/src/components/Resizable.js
@@ -20,6 +20,7 @@ export default class Resizable extends React.Component {
     constructor(props) {
         super(props);
         this.state = { width: 0 };
+        this.handleResize = this.handleResize.bind(this);
     }
 
     componentDidMount() {


### PR DESCRIPTION
Fixes #329 by binding `this` in the constructor of Resizable so the method `handleResize()` can access `this.container` and adjust the width of charts accordingly.  