### PR TITLE
Add options to modify the ChartRow vertical axis margin and vertical EventMarker info box offset.

### DIFF
--- a/lib/components/BarChart.js
+++ b/lib/components/BarChart.js
@@ -633,6 +633,12 @@ BarChart.propTypes = {
     infoHeight: _propTypes2.default.number, //eslint-disable-line
 
     /**
+     * The vertical offset in pixels of the EventMarker info box from the
+     * top of the chart.
+     */
+    infoOffsetY: _propTypes2.default.number,
+
+    /**
      * Alter the format of the timestamp shown on the info box.
      * This may be either a function or a string. If you provide a function
      * that will be passed an Index and should return a string. For example:
@@ -731,5 +737,6 @@ BarChart.defaultProps = {
     },
     markerRadius: 2,
     infoWidth: 90,
-    infoHeight: 30
+    infoHeight: 30,
+    infoOffsetY: 20
 };

--- a/lib/components/BoxChart.js
+++ b/lib/components/BoxChart.js
@@ -929,6 +929,12 @@ BoxChart.propTypes = {
     infoHeight: _propTypes2.default.number, //eslint-disable-line
 
     /**
+     * The vertical offset in pixels of the EventMarker info box from the
+     * top of the chart.
+     */
+    infoOffsetY: _propTypes2.default.number,
+
+    /**
      * The values to show in the info box. This is an array of
      * objects, with each object specifying the label and value
      * to be shown in the info box.
@@ -1033,5 +1039,6 @@ BoxChart.defaultProps = {
     },
     markerRadius: 2,
     infoWidth: 90,
-    infoHeight: 30
+    infoHeight: 30,
+    infoOffsetY: 20
 };

--- a/lib/components/ChartRow.js
+++ b/lib/components/ChartRow.js
@@ -643,7 +643,9 @@ ChartRow.propTypes = {
     height: _propTypes2.default.oneOfType([_propTypes2.default.string, _propTypes2.default.number]),
 
     /**
-     * The axis margin.
+     * The vertical margin between the top and bottom of the chart
+     * height and the top and bottom of the range of the chart.
+     * The default is 5px.
      */
     axisMargin: _propTypes2.default.number,
 

--- a/lib/components/ChartRow.js
+++ b/lib/components/ChartRow.js
@@ -643,9 +643,8 @@ ChartRow.propTypes = {
     height: _propTypes2.default.oneOfType([_propTypes2.default.string, _propTypes2.default.number]),
 
     /**
-     * The vertical margin between the top and bottom of the chart
+     * The vertical margin between the top and bottom of the row
      * height and the top and bottom of the range of the chart.
-     * The default is 5px.
      */
     axisMargin: _propTypes2.default.number,
 
@@ -667,7 +666,7 @@ ChartRow.propTypes = {
      */
     trackerInfoHeight: _propTypes2.default.number,
     /**
-     * Info box value or values to place next to the tracker line
+     * Info box value or values to place next to the tracker line.
      * This is either an array of objects, with each object
      * specifying the label (a string) and value (also a string)
      * to be shown in the info box, or a simple string label.

--- a/lib/components/ChartRow.js
+++ b/lib/components/ChartRow.js
@@ -104,8 +104,6 @@ function _inherits(subClass, superClass) {
  *  LICENSE file in the root directory of this source tree.
  */
 
-var AXIS_MARGIN = 5;
-
 function createScale(yaxis, type, min, max, y0, y1) {
     var scale = void 0;
     if (_underscore2.default.isUndefined(min) || _underscore2.default.isUndefined(max)) {
@@ -198,9 +196,10 @@ var ChartRow = (function(_React$Component) {
             value: function updateScales(props) {
                 var _this2 = this;
 
-                var innerHeight = +props.height - AXIS_MARGIN * 2;
-                var rangeTop = AXIS_MARGIN;
-                var rangeBottom = innerHeight - AXIS_MARGIN;
+                var axisMargin = props.axisMargin;
+                var innerHeight = +props.height - axisMargin * 2;
+                var rangeTop = axisMargin;
+                var rangeBottom = innerHeight - axisMargin;
                 _react2.default.Children.forEach(props.children, function(child) {
                     if (child === null) return;
                     if (_this2.isChildYAxis(child)) {
@@ -288,7 +287,7 @@ var ChartRow = (function(_React$Component) {
                 var axes = []; // Contains all the yAxis elements used in the render
                 var chartList = []; // Contains all the Chart elements used in the render
                 // Dimensions
-                var innerHeight = +this.props.height - AXIS_MARGIN * 2;
+                var innerHeight = +this.props.height - this.props.axisMargin * 2;
 
                 //
                 // Build a map of elements that occupy left or right slots next to the
@@ -633,6 +632,7 @@ ChartRow.defaultProps = {
     trackerTimeFormat: "%b %d %Y %X",
     enablePanZoom: false,
     height: 100,
+    axisMargin: 5,
     visible: true
 };
 
@@ -641,6 +641,11 @@ ChartRow.propTypes = {
      * The height of the row.
      */
     height: _propTypes2.default.oneOfType([_propTypes2.default.string, _propTypes2.default.number]),
+
+    /**
+     * The axis margin.
+     */
+    axisMargin: _propTypes2.default.number,
 
     /**
      * Show or hide this row

--- a/lib/components/EventMarker.js
+++ b/lib/components/EventMarker.js
@@ -301,6 +301,7 @@ var EventMarker = (function(_React$Component) {
                 // order to display them side by side.
                 var posx = this.props.timeScale(t) + this.props.offsetX;
                 var posy = this.props.yScale(value) - this.props.offsetY;
+                var infoOffsetY = this.props.infoOffsetY;
 
                 var infoBoxProps = {
                     align: "left",
@@ -405,15 +406,15 @@ var EventMarker = (function(_React$Component) {
                                 x1: -10,
                                 y1: lineBottom,
                                 x2: -10,
-                                y2: 20
+                                y2: infoOffsetY
                             });
                             horizontalStem = _react2.default.createElement("line", {
                                 pointerEvents: "none",
                                 style: this.props.stemStyle,
                                 x1: -10,
-                                y1: 20,
+                                y1: infoOffsetY,
                                 x2: -2,
-                                y2: 20
+                                y2: infoOffsetY
                             });
                         }
                         dot = _react2.default.createElement("circle", {
@@ -432,15 +433,15 @@ var EventMarker = (function(_React$Component) {
                                 x1: w + 10,
                                 y1: lineBottom,
                                 x2: w + 10,
-                                y2: 20
+                                y2: infoOffsetY
                             });
                             horizontalStem = _react2.default.createElement("line", {
                                 pointerEvents: "none",
                                 style: this.props.stemStyle,
                                 x1: w + 10,
-                                y1: 20,
+                                y1: infoOffsetY,
                                 x2: w + 2,
-                                y2: 20
+                                y2: infoOffsetY
                             });
                         }
                         dot = _react2.default.createElement("circle", {
@@ -462,7 +463,7 @@ var EventMarker = (function(_React$Component) {
                         this.renderTime(event),
                         _react2.default.createElement(
                             "g",
-                            { transform: "translate(0," + 20 + ")" },
+                            { transform: "translate(0," + (infoOffsetY - 10) + ")" },
                             infoBox
                         )
                     );
@@ -594,6 +595,11 @@ EventMarker.propTypes = {
     offsetY: _propTypes2.default.number,
 
     /**
+     * Offset the info box position in the y direction.  Default 20.
+     */
+    infoOffsetY: _propTypes2.default.number,
+
+    /**
      * [Internal] The timeScale supplied by the surrounding ChartContainer
      */
     timeScale: _propTypes2.default.func,
@@ -634,5 +640,6 @@ EventMarker.defaultProps = {
         fill: "#999"
     },
     offsetX: 0,
-    offsetY: 0
+    offsetY: 0,
+    infoOffsetY: 20
 };

--- a/lib/components/EventMarker.js
+++ b/lib/components/EventMarker.js
@@ -460,10 +460,14 @@ var EventMarker = (function(_React$Component) {
                         verticalStem,
                         horizontalStem,
                         dot,
-                        this.renderTime(event),
                         _react2.default.createElement(
                             "g",
-                            { transform: "translate(0," + (infoOffsetY - 10) + ")" },
+                            { transform: "translate(0," + (infoOffsetY - 20) + ")" },
+                            this.renderTime(event)
+                        ),
+                        _react2.default.createElement(
+                            "g",
+                            { transform: "translate(0," + infoOffsetY + ")" },
                             infoBox
                         )
                     );

--- a/lib/components/EventMarker.js
+++ b/lib/components/EventMarker.js
@@ -595,7 +595,8 @@ EventMarker.propTypes = {
     offsetY: _propTypes2.default.number,
 
     /**
-     * Offset the info box position in the y direction.  Default 20.
+     * The vertical offset in pixels of the EventMarker info box from the
+     * top of the chart.  The default is 20.
      */
     infoOffsetY: _propTypes2.default.number,
 

--- a/lib/components/ScatterChart.js
+++ b/lib/components/ScatterChart.js
@@ -654,6 +654,12 @@ ScatterChart.propTypes = {
     infoHeight: _propTypes2.default.number, // eslint-disable-line
 
     /**
+     * The vertical offset in pixels of the EventMarker info box from the
+     * top of the chart.
+     */
+    infoOffsetY: _propTypes2.default.number,
+
+    /**
      * The values to show in the info box. This is an array of
      * objects, with each object specifying the label and value
      * to be shown in the info box.
@@ -741,5 +747,6 @@ ScatterChart.defaultProps = {
         fill: "#999"
     },
     infoWidth: 90,
-    infoHeight: 30
+    infoHeight: 30,
+    infoOffsetY: 20
 };

--- a/src/components/BarChart.js
+++ b/src/components/BarChart.js
@@ -355,9 +355,9 @@ BarChart.propTypes = {
 
     /**
      * A list of columns within the series that will be stacked on top of each other
-     * 
-     * NOTE : Columns can't have periods because periods 
-     * represent a path to deep data in the underlying events 
+     *
+     * NOTE : Columns can't have periods because periods
+     * represent a path to deep data in the underlying events
      * (i.e. reference into nested data structures)
      */
     columns: PropTypes.arrayOf(PropTypes.string),
@@ -434,6 +434,12 @@ BarChart.propTypes = {
      * The height of the info box
      */
     infoHeight: PropTypes.number, //eslint-disable-line
+
+    /**
+     * The vertical offset in pixels of the EventMarker info box from the
+     * top of the chart.
+     */
+    infoOffsetY: PropTypes.number,
 
     /**
      * Alter the format of the timestamp shown on the info box.
@@ -534,5 +540,6 @@ BarChart.defaultProps = {
     },
     markerRadius: 2,
     infoWidth: 90,
-    infoHeight: 30
+    infoHeight: 30,
+    infoOffsetY: 20
 };

--- a/src/components/BoxChart.js
+++ b/src/components/BoxChart.js
@@ -647,9 +647,9 @@ BoxChart.propTypes = {
     /**
      * The column within the TimeSeries to plot. Unlike other charts, the BoxChart
      * works on just a single column.
-     * 
-     * NOTE : Columns can't have periods because periods 
-     * represent a path to deep data in the underlying events 
+     *
+     * NOTE : Columns can't have periods because periods
+     * represent a path to deep data in the underlying events
      * (i.e. reference into nested data structures)
      */
     column: PropTypes.string,
@@ -708,6 +708,12 @@ BoxChart.propTypes = {
      * The height of the hover info box
      */
     infoHeight: PropTypes.number, //eslint-disable-line
+
+    /**
+     * The vertical offset in pixels of the EventMarker info box from the
+     * top of the chart.
+     */
+    infoOffsetY: PropTypes.number,
 
     /**
      * The values to show in the info box. This is an array of
@@ -814,5 +820,6 @@ BoxChart.defaultProps = {
     },
     markerRadius: 2,
     infoWidth: 90,
-    infoHeight: 30
+    infoHeight: 30,
+    infoOffsetY: 20
 };

--- a/src/components/ChartRow.js
+++ b/src/components/ChartRow.js
@@ -480,9 +480,8 @@ ChartRow.propTypes = {
     height: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 
     /**
-     * The vertical margin between the top and bottom of the chart
+     * The vertical margin between the top and bottom of the row
      * height and the top and bottom of the range of the chart.
-     * The default is 5px.
      */
     axisMargin: PropTypes.number,
 
@@ -504,7 +503,7 @@ ChartRow.propTypes = {
      */
     trackerInfoHeight: PropTypes.number,
     /**
-     * Info box value or values to place next to the tracker line
+     * Info box value or values to place next to the tracker line.
      * This is either an array of objects, with each object
      * specifying the label (a string) and value (also a string)
      * to be shown in the info box, or a simple string label.

--- a/src/components/ChartRow.js
+++ b/src/components/ChartRow.js
@@ -22,8 +22,6 @@ import MultiBrush from "./MultiBrush";
 import TimeMarker from "./TimeMarker";
 import ScaleInterpolator from "../js/interpolators";
 
-const AXIS_MARGIN = 5;
-
 function createScale(yaxis, type, min, max, y0, y1) {
     let scale;
     if (_.isUndefined(min) || _.isUndefined(max)) {
@@ -98,9 +96,10 @@ export default class ChartRow extends React.Component {
         (_.has(child.props, "min") && _.has(child.props, "max"));
 
     updateScales(props) {
-        const innerHeight = +props.height - AXIS_MARGIN * 2;
-        const rangeTop = AXIS_MARGIN;
-        const rangeBottom = innerHeight - AXIS_MARGIN;
+        const axisMargin = props.axisMargin;
+        const innerHeight = +props.height - axisMargin * 2;
+        const rangeTop = axisMargin;
+        const rangeBottom = innerHeight - axisMargin;
         React.Children.forEach(props.children, child => {
             if (child === null) return;
             if (this.isChildYAxis(child)) {
@@ -163,7 +162,7 @@ export default class ChartRow extends React.Component {
         const axes = []; // Contains all the yAxis elements used in the render
         const chartList = []; // Contains all the Chart elements used in the render
         // Dimensions
-        const innerHeight = +this.props.height - AXIS_MARGIN * 2;
+        const innerHeight = +this.props.height - this.props.axisMargin * 2;
 
         //
         // Build a map of elements that occupy left or right slots next to the
@@ -470,6 +469,7 @@ ChartRow.defaultProps = {
     trackerTimeFormat: "%b %d %Y %X",
     enablePanZoom: false,
     height: 100,
+    axisMargin: 5,
     visible: true
 };
 
@@ -478,6 +478,11 @@ ChartRow.propTypes = {
      * The height of the row.
      */
     height: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+
+    /**
+     * The axis margin.
+     */
+    axisMargin: PropTypes.number,
 
     /**
      * Show or hide this row

--- a/src/components/ChartRow.js
+++ b/src/components/ChartRow.js
@@ -480,7 +480,9 @@ ChartRow.propTypes = {
     height: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 
     /**
-     * The axis margin.
+     * The vertical margin between the top and bottom of the chart
+     * height and the top and bottom of the range of the chart.
+     * The default is 5px.
      */
     axisMargin: PropTypes.number,
 

--- a/src/components/EventMarker.js
+++ b/src/components/EventMarker.js
@@ -346,8 +346,8 @@ export default class EventMarker extends React.Component {
                     {verticalStem}
                     {horizontalStem}
                     {dot}
-                    {this.renderTime(event)}
-                    <g transform={`translate(0,${infoOffsetY - 10})`}>{infoBox}</g>
+                    <g transform={`translate(0,${infoOffsetY - 20})`}>{this.renderTime(event)}</g>
+                    <g transform={`translate(0,${infoOffsetY})`}>{infoBox}</g>
                 </g>
             );
         }

--- a/src/components/EventMarker.js
+++ b/src/components/EventMarker.js
@@ -459,7 +459,8 @@ EventMarker.propTypes = {
     offsetY: PropTypes.number,
 
     /**
-     * Offset the info box position in the y direction.  Default 20.
+     * The vertical offset in pixels of the EventMarker info box from the
+     * top of the chart.  The default is 20.
      */
     infoOffsetY: PropTypes.number,
 

--- a/src/components/EventMarker.js
+++ b/src/components/EventMarker.js
@@ -179,6 +179,7 @@ export default class EventMarker extends React.Component {
         // order to display them side by side.
         const posx = this.props.timeScale(t) + this.props.offsetX;
         const posy = this.props.yScale(value) - this.props.offsetY;
+        const infoOffsetY = this.props.infoOffsetY;
 
         const infoBoxProps = {
             align: "left",
@@ -272,7 +273,7 @@ export default class EventMarker extends React.Component {
                 </g>
             );
         } else {
-            if (posx + 10 + w < this.props.width * 3 / 4) {
+            if (posx + 10 + w < (this.props.width * 3) / 4) {
                 if (info) {
                     verticalStem = (
                         <line
@@ -281,7 +282,7 @@ export default class EventMarker extends React.Component {
                             x1={-10}
                             y1={lineBottom}
                             x2={-10}
-                            y2={20}
+                            y2={infoOffsetY}
                         />
                     );
                     horizontalStem = (
@@ -289,9 +290,9 @@ export default class EventMarker extends React.Component {
                             pointerEvents="none"
                             style={this.props.stemStyle}
                             x1={-10}
-                            y1={20}
+                            y1={infoOffsetY}
                             x2={-2}
-                            y2={20}
+                            y2={infoOffsetY}
                         />
                     );
                 }
@@ -314,7 +315,7 @@ export default class EventMarker extends React.Component {
                             x1={w + 10}
                             y1={lineBottom}
                             x2={w + 10}
-                            y2={20}
+                            y2={infoOffsetY}
                         />
                     );
                     horizontalStem = (
@@ -322,9 +323,9 @@ export default class EventMarker extends React.Component {
                             pointerEvents="none"
                             style={this.props.stemStyle}
                             x1={w + 10}
-                            y1={20}
+                            y1={infoOffsetY}
                             x2={w + 2}
-                            y2={20}
+                            y2={infoOffsetY}
                         />
                     );
                 }
@@ -346,7 +347,7 @@ export default class EventMarker extends React.Component {
                     {horizontalStem}
                     {dot}
                     {this.renderTime(event)}
-                    <g transform={`translate(0,${20})`}>{infoBox}</g>
+                    <g transform={`translate(0,${infoOffsetY - 10})`}>{infoBox}</g>
                 </g>
             );
         }
@@ -375,9 +376,9 @@ EventMarker.propTypes = {
 
     /**
      * Which column in the Event to use
-     * 
-     * NOTE : Columns can't have periods because periods 
-     * represent a path to deep data in the underlying events 
+     *
+     * NOTE : Columns can't have periods because periods
+     * represent a path to deep data in the underlying events
      * (i.e. reference into nested data structures)
      */
     column: PropTypes.string,
@@ -458,6 +459,11 @@ EventMarker.propTypes = {
     offsetY: PropTypes.number,
 
     /**
+     * Offset the info box position in the y direction.  Default 20.
+     */
+    infoOffsetY: PropTypes.number,
+
+    /**
      * [Internal] The timeScale supplied by the surrounding ChartContainer
      */
     timeScale: PropTypes.func,
@@ -498,5 +504,6 @@ EventMarker.defaultProps = {
         fill: "#999"
     },
     offsetX: 0,
-    offsetY: 0
+    offsetY: 0,
+    infoOffsetY: 20
 };

--- a/src/components/ScatterChart.js
+++ b/src/components/ScatterChart.js
@@ -394,6 +394,12 @@ ScatterChart.propTypes = {
     infoHeight: PropTypes.number, // eslint-disable-line
 
     /**
+     * The vertical offset in pixels of the EventMarker info box from the
+     * top of the chart.
+     */
+    infoOffsetY: PropTypes.number,
+
+    /**
      * The values to show in the info box. This is an array of
      * objects, with each object specifying the label and value
      * to be shown in the info box.
@@ -481,5 +487,6 @@ ScatterChart.defaultProps = {
         fill: "#999"
     },
     infoWidth: 90,
-    infoHeight: 30
+    infoHeight: 30,
+    infoOffsetY: 20
 };

--- a/src/website/packages/charts/api/docs.json
+++ b/src/website/packages/charts/api/docs.json
@@ -916,6 +916,17 @@
           "computed": false
         }
       },
+      "infoOffsetY": {
+        "type": {
+          "name": "number"
+        },
+        "required": false,
+        "description": "The vertical offset in pixels of the EventMarker info box from the\ntop of the chart.",
+        "defaultValue": {
+          "value": "20",
+          "computed": false
+        }
+      },
       "infoTimeFormat": {
         "type": {
           "name": "union",
@@ -1359,6 +1370,17 @@
         "description": "The height of the hover info box",
         "defaultValue": {
           "value": "30",
+          "computed": false
+        }
+      },
+      "infoOffsetY": {
+        "type": {
+          "name": "number"
+        },
+        "required": false,
+        "description": "The vertical offset in pixels of the EventMarker info box from the\ntop of the chart.",
+        "defaultValue": {
+          "value": "20",
           "computed": false
         }
       },
@@ -2192,6 +2214,17 @@
           "computed": false
         }
       },
+      "axisMargin": {
+        "type": {
+          "name": "number"
+        },
+        "required": false,
+        "description": "The vertical margin between the top and bottom of the row\nheight and the top and bottom of the range of the chart.",
+        "defaultValue": {
+          "value": "5",
+          "computed": false
+        }
+      },
       "visible": {
         "type": {
           "name": "bool"
@@ -2250,7 +2283,7 @@
           ]
         },
         "required": false,
-        "description": "Info box value or values to place next to the tracker line\nThis is either an array of objects, with each object\nspecifying the label (a string) and value (also a string)\nto be shown in the info box, or a simple string label."
+        "description": "Info box value or values to place next to the tracker line.\nThis is either an array of objects, with each object\nspecifying the label (a string) and value (also a string)\nto be shown in the info box, or a simple string label."
       },
       "children": {
         "type": {
@@ -2814,7 +2847,7 @@
           "name": "string"
         },
         "required": false,
-        "description": "Which column in the Event to use\n\nNOTE : Columns can't have periods because periods \nrepresent a path to deep data in the underlying events \n(i.e. reference into nested data structures)",
+        "description": "Which column in the Event to use\n\nNOTE : Columns can't have periods because periods\nrepresent a path to deep data in the underlying events\n(i.e. reference into nested data structures)",
         "defaultValue": {
           "value": "\"value\"",
           "computed": false
@@ -2973,6 +3006,17 @@
         "description": "Offset the marker position in the y direction",
         "defaultValue": {
           "value": "0",
+          "computed": false
+        }
+      },
+      "infoOffsetY": {
+        "type": {
+          "name": "number"
+        },
+        "required": false,
+        "description": "The vertical offset in pixels of the EventMarker info box from the\ntop of the chart.  The default is 20.",
+        "defaultValue": {
+          "value": "20",
           "computed": false
         }
       },
@@ -4219,7 +4263,7 @@
           }
         },
         "required": false,
-        "description": "Which columns of the series to render\n\nNOTE : Columns can't have periods because periods \nrepresent a path to deep data in the underlying events \n(i.e. reference into nested data structures)",
+        "description": "Which columns of the series to render\n\nNOTE : Columns can't have periods because periods\nrepresent a path to deep data in the underlying events\n(i.e. reference into nested data structures)",
         "defaultValue": {
           "value": "[\"value\"]",
           "computed": false
@@ -4310,6 +4354,17 @@
         "description": "The height of the hover info box",
         "defaultValue": {
           "value": "30",
+          "computed": false
+        }
+      },
+      "infoOffsetY": {
+        "type": {
+          "name": "number"
+        },
+        "required": false,
+        "description": "The vertical offset in pixels of the EventMarker info box from the\ntop of the chart.",
+        "defaultValue": {
+          "value": "20",
           "computed": false
         }
       },

--- a/src/website/packages/charts/examples/stockchart/Index.js
+++ b/src/website/packages/charts/examples/stockchart/Index.js
@@ -99,6 +99,7 @@ class stockchart extends React.Component {
                 hideWeekends={true}
                 enablePanZoom={true}
                 onTimeRangeChanged={this.handleTimeRangeChange}
+                timeAxisStyle={{ axis: { fill: "none", stroke: "none" } }}
             >
                 <ChartRow height="300">
                     <Charts>
@@ -120,7 +121,7 @@ class stockchart extends React.Component {
                         type={this.state.mode}
                     />
                 </ChartRow>
-                <ChartRow height="200">
+                <ChartRow height="200" axisMargin={0}>
                     <Charts>
                         <BarChart
                             axis="y"

--- a/src/website/packages/charts/examples/wind/Index.js
+++ b/src/website/packages/charts/examples/wind/Index.js
@@ -204,6 +204,7 @@ class wind extends React.Component {
                                             info={infoValues}
                                             infoHeight={28}
                                             infoWidth={110}
+                                            infoOffsetY={10}
                                             infoStyle={{
                                                 fill: "black",
                                                 color: "#DDD"


### PR DESCRIPTION
This adds two new props for finer control of vertical spacing:

- `EventMarker.infoOffsetY` controls the vertical offset in pixels of the `EventMarker` info box from the top of the chart.  The default is 20px, the value that was previously hardcoded.  The prop was also added to components that include `EventMarker` (`BarChart`, `BoxChart`, `ScatterChart`).

- `ChartRow.axisMargin` controls the vertical margin between the top and bottom of the chart height and the top and bottom of the range of the chart.  The default is 5px, the value that was previously hardcoded.

Sample usages were added to the existing stockchart and wind examples.

The motivation for these changes was a `LineChart` we have at Alluvium that is very squat.  The hardcoded values for these parameters took too much vertical space in our use case.  In particular, the default offset of the `EventMarker` info box placed it below the bottom edge of the chart.
