### PR TITLE
YAxis Component now rerenders if min/max changes

### DIFF
--- a/src/components/YAxis.js
+++ b/src/components/YAxis.js
@@ -169,8 +169,10 @@ export default class YAxis extends React.Component {
         }
     }
 
-    shouldComponentUpdate() {
-        return false;
+    shouldComponentUpdate(nextProps) {
+        const minUpdated = this.props.min !== nextProps.min;
+        const maxUpdated = this.props.max !== nextProps.max;
+        return minUpdated || maxUpdated;
     }
 
     yformat(fmt) {


### PR DESCRIPTION
Currently the YAxis components shouldComponentUpdate function returns false at all times. 

This will change that function to return true if either min or max has been updated, causing the YAxis component to rerender.

Fixes issue #346 

d3 does not lose control of the component when it is rerendered as previously thought, so this works just fine. Unless I'm missing something obscure that is breaking. 

Sorry for the slowness of the gif, that's my fault.

![screen recording 2018-12-13 at 9 48 47 am](https://user-images.githubusercontent.com/787028/49950778-1424d680-febe-11e8-9426-83aae76864f0.gif)

