### PR TITLE
Allow label to be updated after initial render

### DIFF
--- a/lib/components/YAxis.js
+++ b/lib/components/YAxis.js
@@ -204,7 +204,8 @@ var YAxis = (function(_React$Component) {
                     this.props.hideAxisLine,
                     this.props.absolute,
                     this.props.type,
-                    this.props.format
+                    this.props.format,
+                    this.props.label
                 );
             }
         },
@@ -220,7 +221,8 @@ var YAxis = (function(_React$Component) {
                     format = nextProps.format,
                     type = nextProps.type,
                     showGrid = nextProps.showGrid,
-                    hideAxisLine = nextProps.hideAxisLine;
+                    hideAxisLine = nextProps.hideAxisLine,
+                    label = nextProps.label;
 
                 if (
                     (0, _util.scaleAsString)(this.props.scale) !== (0, _util.scaleAsString)(scale)
@@ -235,7 +237,8 @@ var YAxis = (function(_React$Component) {
                         hideAxisLine,
                         absolute,
                         type,
-                        format
+                        format,
+                        label
                     );
                 } else if (
                     this.props.format !== format ||
@@ -258,8 +261,11 @@ var YAxis = (function(_React$Component) {
                         hideAxisLine,
                         absolute,
                         type,
-                        format
+                        format,
+                        label
                     );
+                } else if (this.props.label !== label) {
+                    this.updateLabel(label);
                 }
             }
         },
@@ -412,7 +418,8 @@ var YAxis = (function(_React$Component) {
                 hideAxisLine,
                 absolute,
                 type,
-                fmt
+                fmt,
+                label
             ) {
                 var yformat = this.yformat(fmt);
                 var axis = align === "left" ? _d3Axis.axisLeft : _d3Axis.axisRight;
@@ -441,9 +448,10 @@ var YAxis = (function(_React$Component) {
                     .styles(valueStyle)
                     .call(axisGenerator.tickSize(tickSize))
                     .append("text")
-                    .text(this.props.label)
+                    .text(label || this.props.label)
                     .styles(labelStyle)
                     .attr("transform", "rotate(-90)")
+                    .attr("class", "yaxislabel")
                     .attr("y", labelOffset)
                     .attr("dy", ".71em")
                     .attr("text-anchor", "end");
@@ -463,7 +471,8 @@ var YAxis = (function(_React$Component) {
                 hideAxisLine,
                 absolute,
                 type,
-                fmt
+                fmt,
+                label
             ) {
                 var yformat = this.yformat(fmt);
                 var axis = align === "left" ? _d3Axis.axisLeft : _d3Axis.axisRight;
@@ -480,7 +489,17 @@ var YAxis = (function(_React$Component) {
                     .ease(_d3Ease.easeSinOut)
                     .call(axisGenerator.tickSize(tickSize));
 
+                this.updateLabel(label);
+
                 this.postSelect(style, hideAxisLine, height);
+            }
+        },
+        {
+            key: "updateLabel",
+            value: function updateLabel(label) {
+                (0, _d3Selection.select)(_reactDom2.default.findDOMNode(this))
+                    .select(".yaxislabel")
+                    .text(label);
             }
         },
         {

--- a/src/components/YAxis.js
+++ b/src/components/YAxis.js
@@ -112,7 +112,8 @@ export default class YAxis extends React.Component {
             this.props.hideAxisLine,
             this.props.absolute,
             this.props.type,
-            this.props.format
+            this.props.format,
+            this.props.label
         );
     }
 
@@ -127,7 +128,8 @@ export default class YAxis extends React.Component {
             format,
             type,
             showGrid,
-            hideAxisLine
+            hideAxisLine,
+            label
         } = nextProps;
 
         if (scaleAsString(this.props.scale) !== scaleAsString(scale)) {
@@ -141,7 +143,8 @@ export default class YAxis extends React.Component {
                 hideAxisLine,
                 absolute,
                 type,
-                format
+                format,
+                label
             );
         } else if (
             this.props.format !== format ||
@@ -164,8 +167,11 @@ export default class YAxis extends React.Component {
                 hideAxisLine,
                 absolute,
                 type,
-                format
+                format,
+                label
             );
+        } else if (this.props.label !== label) {
+            this.updateLabel(label);
         }
     }
 
@@ -298,7 +304,8 @@ export default class YAxis extends React.Component {
         hideAxisLine,
         absolute,
         type,
-        fmt
+        fmt,
+        label
     ) {
         const yformat = this.yformat(fmt);
         const axis = align === "left" ? axisLeft : axisRight;
@@ -325,9 +332,10 @@ export default class YAxis extends React.Component {
             .styles(valueStyle)
             .call(axisGenerator.tickSize(tickSize))
             .append("text")
-            .text(this.props.label)
+            .text(label || this.props.label)
             .styles(labelStyle)
             .attr("transform", "rotate(-90)")
+            .attr("class", "yaxislabel")
             .attr("y", labelOffset)
             .attr("dy", ".71em")
             .attr("text-anchor", "end");
@@ -345,7 +353,8 @@ export default class YAxis extends React.Component {
         hideAxisLine,
         absolute,
         type,
-        fmt
+        fmt,
+        label
     ) {
         const yformat = this.yformat(fmt);
         const axis = align === "left" ? axisLeft : axisRight;
@@ -362,7 +371,15 @@ export default class YAxis extends React.Component {
             .ease(easeSinOut)
             .call(axisGenerator.tickSize(tickSize));
 
+        this.updateLabel(label);
+
         this.postSelect(style, hideAxisLine, height);
+    }
+
+    updateLabel(label) {
+        select(ReactDOM.findDOMNode(this))
+            .select(".yaxislabel")
+            .text(label);
     }
 
     render() {


### PR DESCRIPTION
Hello!

First of all this is a great project, it has worked very well for us! So thanks for your hard work maintaining it!

We ran into an issue where if we render a data series and then render a different data series (through the same parent component) the label doesn't update. I know the usual solution would be to render multiple Yaxis and toggle their visibility. For us we want that component not to know about every single possible series it could render and instead be able to fetch those dynamically.

I have made a small fix for this which basically makes it so that the label can be updated as the Yaxis component receives new props!

Hopefully you find this solution reasonable, let me know if there is anything I can change!

Cheers,

Konrad