### PR TITLE
Update ChartRow to not call setState when unmounted

### DIFF
--- a/lib/components/ChartRow.js
+++ b/lib/components/ChartRow.js
@@ -189,6 +189,7 @@ var ChartRow = (function(_React$Component) {
             clipId: clipId,
             clipPathURL: clipPathURL
         };
+        _this.mounted = true;
         return _this;
     }
 
@@ -223,7 +224,7 @@ var ChartRow = (function(_React$Component) {
                                 function(s) {
                                     var yAxisScalerMap = _this2.state.yAxisScalerMap;
                                     yAxisScalerMap[id] = s;
-                                    _this2.setState(yAxisScalerMap);
+                                    if (_this2.mounted) _this2.setState(yAxisScalerMap);
                                 }
                             );
                         }
@@ -250,7 +251,7 @@ var ChartRow = (function(_React$Component) {
                     scalerMap[id] = interpolator.scaler();
                 });
 
-                this.setState({ yAxisScalerMap: scalerMap });
+                if (this.mounted) this.setState({ yAxisScalerMap: scalerMap });
             }
         },
         {
@@ -274,6 +275,12 @@ var ChartRow = (function(_React$Component) {
             key: "componentWillReceiveProps",
             value: function componentWillReceiveProps(nextProps) {
                 this.updateScales(nextProps);
+            }
+        },
+        {
+            key: "componentWillUnmount",
+            value: function componentWillUnmount() {
+                this.mounted = false;
             }
         },
         {

--- a/src/components/ChartRow.js
+++ b/src/components/ChartRow.js
@@ -91,6 +91,7 @@ export default class ChartRow extends React.Component {
             clipId,
             clipPathURL
         };
+        this.mounted = true;
     }
 
     isChildYAxis = child =>
@@ -111,7 +112,7 @@ export default class ChartRow extends React.Component {
                     this.scaleMap[id] = new ScaleInterpolator(transition, easeSinOut, s => {
                         const yAxisScalerMap = this.state.yAxisScalerMap;
                         yAxisScalerMap[id] = s;
-                        this.setState(yAxisScalerMap);
+                        if (this.mounted) this.setState(yAxisScalerMap);
                     });
                 }
                 // Get the vertical scale for this y-axis.
@@ -136,7 +137,7 @@ export default class ChartRow extends React.Component {
             scalerMap[id] = interpolator.scaler();
         });
 
-        this.setState({ yAxisScalerMap: scalerMap });
+        if (this.mounted) this.setState({ yAxisScalerMap: scalerMap });
     }
 
     componentWillMount() {
@@ -156,7 +157,9 @@ export default class ChartRow extends React.Component {
     componentWillReceiveProps(nextProps) {
         this.updateScales(nextProps);
     }
-
+    componentWillUnmount() {
+        this.mounted = false;
+    }
     render() {
         const { paddingLeft, paddingRight } = this.props;
 


### PR DESCRIPTION
#246 
I had a similar issue where my parent component was unmounted but ChartRow was still calling setState.  Hope this fixes the issues for other people.