### PR TITLE
fix: intermittently click not work on EventChart on Google Chrome, totally not working on Safari

### DIFF
--- a/lib/components/EventHandler.js
+++ b/lib/components/EventHandler.js
@@ -418,6 +418,7 @@ var EventHandler = (function(_React$Component) {
                             width: Math.abs(
                                 this.state.currentDragZoom - this.state.initialDragZoom
                             ),
+                            pointerEvents: "none",
                             height: this.props.height
                         })
                 );

--- a/src/components/EventHandler.js
+++ b/src/components/EventHandler.js
@@ -86,8 +86,8 @@ export default class EventHandler extends React.Component {
         if (this.props.minDuration) {
             const minDuration = parseInt(this.props.minDuration, 10);
             if (duration < this.props.minDuration) {
-                beginScaled = center - (center - begin) / (end - begin) * minDuration;
-                endScaled = center + (end - center) / (end - begin) * minDuration;
+                beginScaled = center - ((center - begin) / (end - begin)) * minDuration;
+                endScaled = center + ((end - center) / (end - begin)) * minDuration;
             }
         }
 
@@ -317,6 +317,7 @@ export default class EventHandler extends React.Component {
                         y={0}
                         width={Math.abs(this.state.currentDragZoom - this.state.initialDragZoom)}
                         height={this.props.height}
+                        pointerEvents="none"
                     />
                 )}
             </g>


### PR DESCRIPTION
While working on EventChart, we observed that the click event on EventChart is not working 100% of the time. So I open it here just in case if anyone faces the same issue. The issue is very hard to reproduce on Google Chrome but it always happen on Safari.
Through investigation, we notice the following points
- The onSelectionChange of EventChart is binding into `<rect />` (event) directly
- OnMouseDown, there is grey `<rect />` overlay, to visualize dragging area
- My guess: sometimes the grey `<rect />` is on top of the EventChart's `<rect />` which prevent the event to be fired.

This change just makes sure that the grey `<rect />` are not accepting pointer events (hence the EventChart's `<rect />` would receive it) since it just to visualize the dragging area, it should not affect anything.