### PR TITLE
Fix YAxis rerender on tickCount/min/max change

### DIFF
--- a/lib/components/ChartContainer.js
+++ b/lib/components/ChartContainer.js
@@ -135,6 +135,18 @@ var defaultTitleStyle = {
     fill: "#C0C0C0"
 };
 
+var defaultChartRowTitleLabelStyle = {
+    fontWeight: 100,
+    fontSize: 13,
+    font: '"Goudy Bookletter 1911", sans-serif"',
+    fill: "#000"
+};
+
+var defaultChartRowTitleBoxStyle = {
+    fill: "white",
+    stroke: "none"
+};
+
 var defaultTrackerStyle = {
     line: {
         stroke: "#999",
@@ -189,6 +201,7 @@ var ChartContainer = (function(_React$Component) {
         _this.handleTimeRangeChanged = _this.handleTimeRangeChanged.bind(_this);
         _this.handleMouseMove = _this.handleMouseMove.bind(_this);
         _this.handleMouseOut = _this.handleMouseOut.bind(_this);
+        _this.handleContextMenu = _this.handleContextMenu.bind(_this);
         _this.handleBackgroundClick = _this.handleBackgroundClick.bind(_this);
         _this.handleZoom = _this.handleZoom.bind(_this);
         _this.saveSvgRef = _this.saveSvgRef.bind(_this);
@@ -247,6 +260,17 @@ var ChartContainer = (function(_React$Component) {
             }
         },
         {
+            key: "handleContextMenu",
+            value: function handleContextMenu(x, y) {
+                if (this.props.onContextMenu) {
+                    var t = this.props.scale
+                        ? this.props.scale.invert(x)
+                        : this.timeScale.invert(x);
+                    this.props.onContextMenu(x, y, t);
+                }
+            }
+        },
+        {
             key: "handleBackgroundClick",
             value: function handleBackgroundClick(x, y) {
                 if (this.props.onBackgroundClick) {
@@ -302,6 +326,7 @@ var ChartContainer = (function(_React$Component) {
                 }
 
                 var chartRows = [];
+                var chartRowTitles = [];
                 var leftAxisWidths = [];
                 var rightAxisWidths = [];
 
@@ -520,8 +545,21 @@ var ChartContainer = (function(_React$Component) {
                             onTimeRangeChanged: _this3.handleTimeRangeChanged,
                             onTrackerChanged: _this3.handleTrackerChanged
                         };
+
+                        var _child$props$titleHei = child.props.titleHeight,
+                            _titleHeight =
+                                _child$props$titleHei === undefined ? 28 : _child$props$titleHei;
+
+                        if (_underscore2.default.isUndefined(child.props.title)) {
+                            _titleHeight = 0;
+                        }
+
                         var _transform =
-                            "translate(" + (-leftWidth - paddingLeft) + "," + yPosition + ")";
+                            "translate(" +
+                            (-leftWidth - paddingLeft) +
+                            "," +
+                            (yPosition + _titleHeight) +
+                            ")";
                         if (isVisible) {
                             chartRows.push(
                                 _react2.default.createElement(
@@ -531,7 +569,44 @@ var ChartContainer = (function(_React$Component) {
                                 )
                             );
 
-                            var height = parseInt(child.props.height, 10);
+                            if (!_underscore2.default.isUndefined(child.props.title)) {
+                                var rowTitleKey = "chart-row-row-title-" + i;
+
+                                var titleLabelStyle = (0, _merge2.default)(
+                                    true,
+                                    defaultChartRowTitleLabelStyle,
+                                    child.props.titleStyle ? child.props.titleStyle : {}
+                                );
+                                var titleBoxStyle = (0, _merge2.default)(
+                                    true,
+                                    defaultChartRowTitleBoxStyle,
+                                    child.props.titleBoxStyle ? child.props.titleBoxStyle : {}
+                                );
+                                var titleTransform =
+                                    "translate(" +
+                                    (-leftWidth - paddingLeft) +
+                                    "," +
+                                    yPosition +
+                                    ")";
+                                var _title = _react2.default.createElement(
+                                    "g",
+                                    { transform: titleTransform, key: rowTitleKey },
+                                    _react2.default.createElement(_Label2.default, {
+                                        align: "left",
+                                        label: child.props.title,
+                                        style: {
+                                            label: titleLabelStyle,
+                                            box: titleBoxStyle
+                                        },
+                                        width: props.width,
+                                        height: _titleHeight
+                                    })
+                                );
+
+                                chartRowTitles.push(_title);
+                            }
+
+                            var height = parseInt(child.props.height, 10) + _titleHeight;
                             yPosition += height;
                             chartsHeight += height;
                         }
@@ -649,10 +724,24 @@ var ChartContainer = (function(_React$Component) {
                             onMouseOut: this.handleMouseOut,
                             onMouseMove: this.handleMouseMove,
                             onMouseClick: this.handleBackgroundClick,
+                            onContextMenu: this.handleContextMenu,
                             onZoom: this.handleZoom
                         },
                         chartRows
                     )
+                );
+
+                var rowTitles = _react2.default.createElement(
+                    "g",
+                    {
+                        transform:
+                            "translate(" +
+                            (leftWidth + paddingLeft) +
+                            "," +
+                            (paddingTop + titleHeight) +
+                            ")"
+                    },
+                    chartRowTitles
                 );
 
                 //
@@ -682,7 +771,8 @@ var ChartContainer = (function(_React$Component) {
                           title,
                           rows,
                           tracker,
-                          timeAxis
+                          timeAxis,
+                          rowTitles
                       )
                     : _react2.default.createElement(
                           "svg",
@@ -695,6 +785,7 @@ var ChartContainer = (function(_React$Component) {
                           title,
                           timeAxis,
                           rows,
+                          rowTitles,
                           tracker
                       );
             }
@@ -899,6 +990,11 @@ ChartContainer.propTypes = {
      * useful when deselecting elements.
      */
     onBackgroundClick: _propTypes2.default.func,
+
+    /**
+     * Called when the user context-clicks the chart
+     */
+    onContextMenu: _propTypes2.default.func,
 
     /**
      * Props for handling the padding

--- a/lib/components/ChartRow.js
+++ b/lib/components/ChartRow.js
@@ -199,7 +199,7 @@ var ChartRow = (function(_React$Component) {
             value: function updateScales(props) {
                 var _this2 = this;
 
-                var innerHeight = +props.height - AXIS_MARGIN * 2;
+                var innerHeight = +this.props.height - AXIS_MARGIN * 2;
                 var rangeTop = AXIS_MARGIN;
                 var rangeBottom = innerHeight - AXIS_MARGIN;
                 _react2.default.Children.forEach(props.children, function(child) {
@@ -681,6 +681,26 @@ ChartRow.propTypes = {
             })
         )
     ]),
+
+    /**
+     * Specify the title for the chart row
+     */
+    title: _propTypes2.default.string,
+
+    /**
+     * Specify the height of the title
+     * Default value is 28 pixels
+     */
+    titleHeight: _propTypes2.default.number,
+
+    /**
+     * Specify the styling of the chart row's title
+     */
+    titleStyle: _propTypes2.default.object,
+    /**
+     * Specify the styling of the box behind chart row's title
+     */
+    titleBoxStyle: _propTypes2.default.object,
 
     children: _propTypes2.default.oneOfType([
         _propTypes2.default.arrayOf(_propTypes2.default.node),

--- a/lib/components/EventHandler.js
+++ b/lib/components/EventHandler.js
@@ -125,6 +125,7 @@ var EventHandler = (function(_React$Component) {
         _this.handleMouseUp = _this.handleMouseUp.bind(_this);
         _this.handleMouseOut = _this.handleMouseOut.bind(_this);
         _this.handleMouseMove = _this.handleMouseMove.bind(_this);
+        _this.handleContextMenu = _this.handleContextMenu.bind(_this);
         return _this;
     }
 
@@ -214,6 +215,10 @@ var EventHandler = (function(_React$Component) {
             key: "handleMouseDown",
             value: function handleMouseDown(e) {
                 if (!this.props.enablePanZoom && !this.props.enableDragZoom) {
+                    return;
+                }
+
+                if (e.button === 2) {
                     return;
                 }
 
@@ -377,6 +382,16 @@ var EventHandler = (function(_React$Component) {
                     }
                 }
             }
+        },
+        {
+            key: "handleContextMenu",
+            value: function handleContextMenu(e) {
+                var x = e.pageX;
+                var y = e.pageY;
+                if (this.props.onContextMenu) {
+                    this.props.onContextMenu(x, y);
+                }
+            }
 
             //
             // Render
@@ -393,7 +408,8 @@ var EventHandler = (function(_React$Component) {
                     onMouseDown: this.handleMouseDown,
                     onMouseMove: this.handleMouseMove,
                     onMouseOut: this.handleMouseOut,
-                    onMouseUp: this.handleMouseUp
+                    onMouseUp: this.handleMouseUp,
+                    onContextMenu: this.handleContextMenu
                 };
                 return _react2.default.createElement(
                     "g",
@@ -446,7 +462,8 @@ EventHandler.propTypes = {
     onZoom: _propTypes2.default.func,
     onMouseMove: _propTypes2.default.func,
     onMouseOut: _propTypes2.default.func,
-    onMouseClick: _propTypes2.default.func
+    onMouseClick: _propTypes2.default.func,
+    onContextMenu: _propTypes2.default.func
 };
 
 EventHandler.defaultProps = {

--- a/lib/components/EventMarker.js
+++ b/lib/components/EventMarker.js
@@ -467,7 +467,7 @@ var EventMarker = (function(_React$Component) {
                         this.renderTime(event),
                         _react2.default.createElement(
                             "g",
-                            { transform: "translate(0," + 20 + ")" },
+                            { transform: "translate(0," + this.props.offsetInfoBox + ")" },
                             infoBox
                         )
                     );
@@ -599,6 +599,11 @@ EventMarker.propTypes = {
     offsetY: _propTypes2.default.number,
 
     /**
+     * Offset the infobox position in the y direction
+     */
+    offsetInfoBox: _propTypes2.default.number,
+
+    /**
      * [Internal] The timeScale supplied by the surrounding ChartContainer
      */
     timeScale: _propTypes2.default.func,
@@ -639,5 +644,6 @@ EventMarker.defaultProps = {
         fill: "#999"
     },
     offsetX: 0,
-    offsetY: 0
+    offsetY: 0,
+    offsetInfoBox: 20
 };

--- a/lib/components/YAxis.js
+++ b/lib/components/YAxis.js
@@ -205,7 +205,10 @@ var YAxis = (function(_React$Component) {
                     this.props.absolute,
                     this.props.type,
                     this.props.format,
-                    this.props.label
+                    this.props.label,
+                    this.props.tickCount,
+                    this.props.min,
+                    this.props.max
                 );
             }
         },
@@ -222,7 +225,10 @@ var YAxis = (function(_React$Component) {
                     type = nextProps.type,
                     showGrid = nextProps.showGrid,
                     hideAxisLine = nextProps.hideAxisLine,
-                    label = nextProps.label;
+                    label = nextProps.label,
+                    tickCount = nextProps.tickCount,
+                    min = nextProps.min,
+                    max = nextProps.max;
 
                 if (
                     (0, _util.scaleAsString)(this.props.scale) !== (0, _util.scaleAsString)(scale)
@@ -238,7 +244,10 @@ var YAxis = (function(_React$Component) {
                         absolute,
                         type,
                         format,
-                        label
+                        label,
+                        tickCount,
+                        min,
+                        max
                     );
                 } else if (
                     this.props.format !== format ||
@@ -262,7 +271,10 @@ var YAxis = (function(_React$Component) {
                         absolute,
                         type,
                         format,
-                        label
+                        label,
+                        tickCount,
+                        min,
+                        max
                     );
                 } else if (this.props.label !== label) {
                     this.updateLabel(label);
@@ -352,20 +364,23 @@ var YAxis = (function(_React$Component) {
         },
         {
             key: "generator",
-            value: function generator(type, absolute, yformat, axis, scale) {
+            value: function generator(
+                type,
+                absolute,
+                yformat,
+                axis,
+                scale,
+                height,
+                tickCount,
+                min,
+                max
+            ) {
                 var axisGenerator = void 0;
                 if (type === "linear" || type === "power") {
-                    if (this.props.tickCount > 0) {
-                        var stepSize =
-                            (this.props.max - this.props.min) / (this.props.tickCount - 1);
+                    if (tickCount > 0) {
+                        var stepSize = (max - min) / (tickCount - 1);
                         axisGenerator = axis(scale)
-                            .tickValues(
-                                (0, _d3Array.range)(
-                                    this.props.min,
-                                    this.props.max + this.props.max / 10000,
-                                    stepSize
-                                )
-                            )
+                            .tickValues((0, _d3Array.range)(min, max + max / 10000, stepSize))
                             .tickFormat(function(d) {
                                 if (absolute) {
                                     return yformat(Math.abs(d));
@@ -374,7 +389,7 @@ var YAxis = (function(_React$Component) {
                             })
                             .tickSizeOuter(0);
                     } else {
-                        if (this.props.height <= 200) {
+                        if (height <= 200) {
                             axisGenerator = axis(scale)
                                 .ticks(4)
                                 .tickFormat(function(d) {
@@ -396,7 +411,7 @@ var YAxis = (function(_React$Component) {
                         }
                     }
                 } else if (type === "log") {
-                    if (this.props.min === 0) {
+                    if (min === 0) {
                         throw Error("In a log scale, minimum value can't be 0");
                     }
                     axisGenerator = axis(scale)
@@ -419,7 +434,10 @@ var YAxis = (function(_React$Component) {
                 absolute,
                 type,
                 fmt,
-                label
+                label,
+                tickCount,
+                min,
+                max
             ) {
                 var yformat = this.yformat(fmt);
                 var axis = align === "left" ? _d3Axis.axisLeft : _d3Axis.axisRight;
@@ -433,7 +451,17 @@ var YAxis = (function(_React$Component) {
                     align === "left" ? this.props.labelOffset - 50 : 40 + this.props.labelOffset;
 
                 // Axis generator
-                var axisGenerator = this.generator(type, absolute, yformat, axis, scale);
+                var axisGenerator = this.generator(
+                    type,
+                    absolute,
+                    yformat,
+                    axis,
+                    scale,
+                    height,
+                    tickCount,
+                    min,
+                    max
+                );
 
                 // Remove the old axis from under this DOM node
                 (0, _d3Selection.select)(_reactDom2.default.findDOMNode(this))
@@ -472,14 +500,27 @@ var YAxis = (function(_React$Component) {
                 absolute,
                 type,
                 fmt,
-                label
+                label,
+                tickCount,
+                min,
+                max
             ) {
                 var yformat = this.yformat(fmt);
                 var axis = align === "left" ? _d3Axis.axisLeft : _d3Axis.axisRight;
                 var style = this.mergeStyles(this.props.style);
                 var tickSize = showGrid && this.props.isInnerAxis ? -chartExtent : 5;
 
-                var axisGenerator = this.generator(type, absolute, yformat, axis, scale, tickSize);
+                var axisGenerator = this.generator(
+                    type,
+                    absolute,
+                    yformat,
+                    axis,
+                    scale,
+                    height,
+                    tickCount,
+                    min,
+                    max
+                );
 
                 // Transition the existing axis
                 (0, _d3Selection.select)(_reactDom2.default.findDOMNode(this))

--- a/src/components/YAxis.js
+++ b/src/components/YAxis.js
@@ -113,7 +113,10 @@ export default class YAxis extends React.Component {
             this.props.absolute,
             this.props.type,
             this.props.format,
-            this.props.label
+            this.props.label,
+            this.props.tickCount,
+            this.props.min,
+            this.props.max
         );
     }
 
@@ -129,7 +132,10 @@ export default class YAxis extends React.Component {
             type,
             showGrid,
             hideAxisLine,
-            label
+            label,
+            tickCount,
+            min,
+            max
         } = nextProps;
 
         if (scaleAsString(this.props.scale) !== scaleAsString(scale)) {
@@ -144,7 +150,10 @@ export default class YAxis extends React.Component {
                 absolute,
                 type,
                 format,
-                label
+                label,
+                tickCount,
+                min,
+                max
             );
         } else if (
             this.props.format !== format ||
@@ -168,7 +177,10 @@ export default class YAxis extends React.Component {
                 absolute,
                 type,
                 format,
-                label
+                label,
+                tickCount,
+                min,
+                max
             );
         } else if (this.props.label !== label) {
             this.updateLabel(label);
@@ -245,15 +257,13 @@ export default class YAxis extends React.Component {
         }
     }
 
-    generator(type, absolute, yformat, axis, scale) {
+    generator(type, absolute, yformat, axis, scale, height, tickCount, min, max) {
         let axisGenerator;
         if (type === "linear" || type === "power") {
-            if (this.props.tickCount > 0) {
-                const stepSize = (this.props.max - this.props.min) / (this.props.tickCount - 1);
+            if (tickCount > 0) {
+                const stepSize = (max - min) / (tickCount - 1);
                 axisGenerator = axis(scale)
-                    .tickValues(
-                        range(this.props.min, this.props.max + this.props.max / 10000, stepSize)
-                    )
+                    .tickValues(range(min, max + max / 10000, stepSize))
                     .tickFormat(d => {
                         if (absolute) {
                             return yformat(Math.abs(d));
@@ -262,7 +272,7 @@ export default class YAxis extends React.Component {
                     })
                     .tickSizeOuter(0);
             } else {
-                if (this.props.height <= 200) {
+                if (height <= 200) {
                     axisGenerator = axis(scale)
                         .ticks(4)
                         .tickFormat(d => {
@@ -284,7 +294,7 @@ export default class YAxis extends React.Component {
                 }
             }
         } else if (type === "log") {
-            if (this.props.min === 0) {
+            if (min === 0) {
                 throw Error("In a log scale, minimum value can't be 0");
             }
             axisGenerator = axis(scale)
@@ -305,7 +315,10 @@ export default class YAxis extends React.Component {
         absolute,
         type,
         fmt,
-        label
+        label,
+        tickCount,
+        min,
+        max
     ) {
         const yformat = this.yformat(fmt);
         const axis = align === "left" ? axisLeft : axisRight;
@@ -317,7 +330,17 @@ export default class YAxis extends React.Component {
             align === "left" ? this.props.labelOffset - 50 : 40 + this.props.labelOffset;
 
         // Axis generator
-        const axisGenerator = this.generator(type, absolute, yformat, axis, scale);
+        const axisGenerator = this.generator(
+            type,
+            absolute,
+            yformat,
+            axis,
+            scale,
+            height,
+            tickCount,
+            min,
+            max
+        );
 
         // Remove the old axis from under this DOM node
         select(ReactDOM.findDOMNode(this))
@@ -354,14 +377,27 @@ export default class YAxis extends React.Component {
         absolute,
         type,
         fmt,
-        label
+        label,
+        tickCount,
+        min,
+        max
     ) {
         const yformat = this.yformat(fmt);
         const axis = align === "left" ? axisLeft : axisRight;
         const style = this.mergeStyles(this.props.style);
         const tickSize = showGrid && this.props.isInnerAxis ? -chartExtent : 5;
 
-        const axisGenerator = this.generator(type, absolute, yformat, axis, scale, tickSize);
+        const axisGenerator = this.generator(
+            type,
+            absolute,
+            yformat,
+            axis,
+            scale,
+            height,
+            tickCount,
+            min,
+            max
+        );
 
         // Transition the existing axis
         select(ReactDOM.findDOMNode(this))


### PR DESCRIPTION
Hello again! Here is my fix for the issue I reported.

Issue: https://github.com/esnet/react-timeseries-charts/issues/371

I have previously committed to this component with a different fix. Also this is a small bug with a fairly simple solution so hopefully this gets merged quickly! Thanks again for all your hard work on this library!

Also when I ran the build step it looks like some other stuff got built too :man_shrugging: , see my first commit for the actual code changes!

Fixed Screenshots:
On first render:
![screenshot from 2019-02-12 22-37-43](https://user-images.githubusercontent.com/9980985/52689529-be999400-2f17-11e9-9670-7f1b7f89acd5.png)
After changing tickCount/min/max:
![screenshot from 2019-02-12 22-43-56](https://user-images.githubusercontent.com/9980985/52689534-c1948480-2f17-11e9-993c-61846e669684.png)

See Issue for broken screenshots.

Cheers,

Konrad