### PR TITLE
Add styling option

### DIFF
--- a/lib/components/BarChart.js
+++ b/lib/components/BarChart.js
@@ -633,6 +633,12 @@ BarChart.propTypes = {
     infoHeight: _propTypes2.default.number, //eslint-disable-line
 
     /**
+     * The vertical offset in pixels of the EventMarker info box from the
+     * top of the chart.
+     */
+    infoOffsetY: _propTypes2.default.number,
+
+    /**
      * Alter the format of the timestamp shown on the info box.
      * This may be either a function or a string. If you provide a function
      * that will be passed an Index and should return a string. For example:
@@ -731,5 +737,6 @@ BarChart.defaultProps = {
     },
     markerRadius: 2,
     infoWidth: 90,
-    infoHeight: 30
+    infoHeight: 30,
+    infoOffsetY: 20
 };

--- a/lib/components/BoxChart.js
+++ b/lib/components/BoxChart.js
@@ -929,6 +929,12 @@ BoxChart.propTypes = {
     infoHeight: _propTypes2.default.number, //eslint-disable-line
 
     /**
+     * The vertical offset in pixels of the EventMarker info box from the
+     * top of the chart.
+     */
+    infoOffsetY: _propTypes2.default.number,
+
+    /**
      * The values to show in the info box. This is an array of
      * objects, with each object specifying the label and value
      * to be shown in the info box.
@@ -1033,5 +1039,6 @@ BoxChart.defaultProps = {
     },
     markerRadius: 2,
     infoWidth: 90,
-    infoHeight: 30
+    infoHeight: 30,
+    infoOffsetY: 20
 };

--- a/lib/components/ChartRow.js
+++ b/lib/components/ChartRow.js
@@ -199,9 +199,10 @@ var ChartRow = (function(_React$Component) {
             value: function updateScales(props) {
                 var _this2 = this;
 
-                var innerHeight = +this.props.height - AXIS_MARGIN * 2;
-                var rangeTop = AXIS_MARGIN;
-                var rangeBottom = innerHeight - AXIS_MARGIN;
+                var axisMargin = props.axisMargin;
+                var innerHeight = +props.height - axisMargin * 2;
+                var rangeTop = axisMargin;
+                var rangeBottom = innerHeight - axisMargin;
                 _react2.default.Children.forEach(props.children, function(child) {
                     if (child === null) return;
                     if (_this2.isChildYAxis(child)) {
@@ -295,7 +296,7 @@ var ChartRow = (function(_React$Component) {
                 var axes = []; // Contains all the yAxis elements used in the render
                 var chartList = []; // Contains all the Chart elements used in the render
                 // Dimensions
-                var innerHeight = +this.props.height - AXIS_MARGIN * 2;
+                var innerHeight = +this.props.height - this.props.axisMargin * 2;
 
                 //
                 // Build a map of elements that occupy left or right slots next to the
@@ -640,6 +641,7 @@ ChartRow.defaultProps = {
     trackerTimeFormat: "%b %d %Y %X",
     enablePanZoom: false,
     height: 100,
+    axisMargin: 5,
     visible: true
 };
 
@@ -650,6 +652,12 @@ ChartRow.propTypes = {
     height: _propTypes2.default.oneOfType([_propTypes2.default.string, _propTypes2.default.number]),
 
     /**
+     * The vertical margin between the top and bottom of the row
+     * height and the top and bottom of the range of the chart.
+     */
+    axisMargin: _propTypes2.default.number,
+
+    /**
      * Show or hide this row
      */
     visible: _propTypes2.default.bool,
@@ -658,16 +666,19 @@ ChartRow.propTypes = {
      * Should the time be shown on top of the tracker info box
      */
     trackerShowTime: _propTypes2.default.bool,
+
     /**
      * The width of the tracker info box
      */
     trackerInfoWidth: _propTypes2.default.number,
+
     /**
      * The height of the tracker info box
      */
     trackerInfoHeight: _propTypes2.default.number,
+
     /**
-     * Info box value or values to place next to the tracker line
+     * Info box value or values to place next to the tracker line.
      * This is either an array of objects, with each object
      * specifying the label (a string) and value (also a string)
      * to be shown in the info box, or a simple string label.
@@ -697,6 +708,7 @@ ChartRow.propTypes = {
      * Specify the styling of the chart row's title
      */
     titleStyle: _propTypes2.default.object,
+
     /**
      * Specify the styling of the box behind chart row's title
      */

--- a/lib/components/EventHandler.js
+++ b/lib/components/EventHandler.js
@@ -4,20 +4,6 @@ Object.defineProperty(exports, "__esModule", {
     value: true
 });
 
-var _extends =
-    Object.assign ||
-    function(target) {
-        for (var i = 1; i < arguments.length; i++) {
-            var source = arguments[i];
-            for (var key in source) {
-                if (Object.prototype.hasOwnProperty.call(source, key)) {
-                    target[key] = source[key];
-                }
-            }
-        }
-        return target;
-    };
-
 var _createClass = (function() {
     function defineProperties(target, props) {
         for (var i = 0; i < props.length; i++) {
@@ -129,9 +115,29 @@ var EventHandler = (function(_React$Component) {
         return _this;
     }
 
-    // get the event mouse position relative to the event rect
-
     _createClass(EventHandler, [
+        {
+            key: "componentDidMount",
+            value: function componentDidMount() {
+                var _this2 = this;
+
+                var handlers = {
+                    wheel: this.handleScrollWheel,
+                    mousedown: this.handleMouseDown,
+                    mousemove: this.handleMouseMove,
+                    mouseout: this.handleMouseOut,
+                    mouseup: this.handleMouseUp,
+                    contextmenu: this.handleContextMenu
+                };
+
+                Object.keys(handlers).forEach(function(type) {
+                    var handlerFunc = handlers[type];
+                    _this2.eventHandlerRef.addEventListener(type, handlerFunc, { passive: false });
+                });
+            }
+
+            // get the event mouse position relative to the event rect
+        },
         {
             key: "getOffsetMousePosition",
             value: function getOffsetMousePosition(e) {
@@ -400,24 +406,22 @@ var EventHandler = (function(_React$Component) {
         {
             key: "render",
             value: function render() {
-                var _this2 = this;
+                var _this3 = this;
 
                 var cursor = this.state.isPanning ? "-webkit-grabbing" : "default";
-                var handlers = {
-                    onWheel: this.handleScrollWheel,
-                    onMouseDown: this.handleMouseDown,
-                    onMouseMove: this.handleMouseMove,
-                    onMouseOut: this.handleMouseOut,
-                    onMouseUp: this.handleMouseUp,
-                    onContextMenu: this.handleContextMenu
-                };
+
                 return _react2.default.createElement(
                     "g",
-                    _extends({ pointerEvents: "all" }, handlers),
+                    {
+                        pointerEvents: "all",
+                        ref: function ref(c) {
+                            _this3.eventHandlerRef = c;
+                        }
+                    },
                     _react2.default.createElement("rect", {
                         key: "handler-hit-rect",
                         ref: function ref(c) {
-                            _this2.eventRect = c;
+                            _this3.eventRect = c;
                         },
                         style: { fill: "#000", opacity: 0.0, cursor: cursor },
                         x: 0,
@@ -434,8 +438,8 @@ var EventHandler = (function(_React$Component) {
                             width: Math.abs(
                                 this.state.currentDragZoom - this.state.initialDragZoom
                             ),
-                            pointerEvents: "none",
-                            height: this.props.height
+                            height: this.props.height,
+                            pointerEvents: "none"
                         })
                 );
             }

--- a/lib/components/EventMarker.js
+++ b/lib/components/EventMarker.js
@@ -306,6 +306,7 @@ var EventMarker = (function(_React$Component) {
                 // order to display them side by side.
                 var posx = this.props.timeScale(t) + this.props.offsetX;
                 var posy = this.props.yScale(value) - this.props.offsetY;
+                var infoOffsetY = this.props.infoOffsetY;
 
                 var infoBoxProps = {
                     align: "left",
@@ -410,15 +411,15 @@ var EventMarker = (function(_React$Component) {
                                 x1: -10,
                                 y1: lineBottom,
                                 x2: -10,
-                                y2: 20
+                                y2: infoOffsetY
                             });
                             horizontalStem = _react2.default.createElement("line", {
                                 pointerEvents: "none",
                                 style: this.props.stemStyle,
                                 x1: -10,
-                                y1: 20,
+                                y1: infoOffsetY,
                                 x2: -2,
-                                y2: 20
+                                y2: infoOffsetY
                             });
                         }
                         dot = _react2.default.createElement("circle", {
@@ -437,15 +438,15 @@ var EventMarker = (function(_React$Component) {
                                 x1: w + 10,
                                 y1: lineBottom,
                                 x2: w + 10,
-                                y2: 20
+                                y2: infoOffsetY
                             });
                             horizontalStem = _react2.default.createElement("line", {
                                 pointerEvents: "none",
                                 style: this.props.stemStyle,
                                 x1: w + 10,
-                                y1: 20,
+                                y1: infoOffsetY,
                                 x2: w + 2,
-                                y2: 20
+                                y2: infoOffsetY
                             });
                         }
                         dot = _react2.default.createElement("circle", {
@@ -464,10 +465,14 @@ var EventMarker = (function(_React$Component) {
                         verticalStem,
                         horizontalStem,
                         dot,
-                        this.renderTime(event),
                         _react2.default.createElement(
                             "g",
-                            { transform: "translate(0," + this.props.offsetInfoBox + ")" },
+                            { transform: "translate(0," + (infoOffsetY - 20) + ")" },
+                            this.renderTime(event)
+                        ),
+                        _react2.default.createElement(
+                            "g",
+                            { transform: "translate(0," + infoOffsetY + ")" },
                             infoBox
                         )
                     );
@@ -599,9 +604,10 @@ EventMarker.propTypes = {
     offsetY: _propTypes2.default.number,
 
     /**
-     * Offset the infobox position in the y direction
+     * The vertical offset in pixels of the EventMarker info box from the
+     * top of the chart. The default is 20.
      */
-    offsetInfoBox: _propTypes2.default.number,
+    infoOffsetY: _propTypes2.default.number,
 
     /**
      * [Internal] The timeScale supplied by the surrounding ChartContainer
@@ -645,5 +651,5 @@ EventMarker.defaultProps = {
     },
     offsetX: 0,
     offsetY: 0,
-    offsetInfoBox: 20
+    infoOffsetY: 20
 };

--- a/lib/components/ScatterChart.js
+++ b/lib/components/ScatterChart.js
@@ -654,6 +654,12 @@ ScatterChart.propTypes = {
     infoHeight: _propTypes2.default.number, // eslint-disable-line
 
     /**
+     * The vertical offset in pixels of the EventMarker info box from the
+     * top of the chart.
+     */
+    infoOffsetY: _propTypes2.default.number,
+
+    /**
      * The values to show in the info box. This is an array of
      * objects, with each object specifying the label and value
      * to be shown in the info box.
@@ -741,5 +747,6 @@ ScatterChart.defaultProps = {
         fill: "#999"
     },
     infoWidth: 90,
-    infoHeight: 30
+    infoHeight: 30,
+    infoOffsetY: 20
 };

--- a/src/components/BarChart.js
+++ b/src/components/BarChart.js
@@ -355,9 +355,9 @@ BarChart.propTypes = {
 
     /**
      * A list of columns within the series that will be stacked on top of each other
-     * 
-     * NOTE : Columns can't have periods because periods 
-     * represent a path to deep data in the underlying events 
+     *
+     * NOTE : Columns can't have periods because periods
+     * represent a path to deep data in the underlying events
      * (i.e. reference into nested data structures)
      */
     columns: PropTypes.arrayOf(PropTypes.string),
@@ -434,6 +434,12 @@ BarChart.propTypes = {
      * The height of the info box
      */
     infoHeight: PropTypes.number, //eslint-disable-line
+
+    /**
+     * The vertical offset in pixels of the EventMarker info box from the
+     * top of the chart.
+     */
+    infoOffsetY: PropTypes.number,
 
     /**
      * Alter the format of the timestamp shown on the info box.
@@ -534,5 +540,6 @@ BarChart.defaultProps = {
     },
     markerRadius: 2,
     infoWidth: 90,
-    infoHeight: 30
+    infoHeight: 30,
+    infoOffsetY: 20
 };

--- a/src/components/BoxChart.js
+++ b/src/components/BoxChart.js
@@ -647,9 +647,9 @@ BoxChart.propTypes = {
     /**
      * The column within the TimeSeries to plot. Unlike other charts, the BoxChart
      * works on just a single column.
-     * 
-     * NOTE : Columns can't have periods because periods 
-     * represent a path to deep data in the underlying events 
+     *
+     * NOTE : Columns can't have periods because periods
+     * represent a path to deep data in the underlying events
      * (i.e. reference into nested data structures)
      */
     column: PropTypes.string,
@@ -708,6 +708,12 @@ BoxChart.propTypes = {
      * The height of the hover info box
      */
     infoHeight: PropTypes.number, //eslint-disable-line
+
+    /**
+     * The vertical offset in pixels of the EventMarker info box from the
+     * top of the chart.
+     */
+    infoOffsetY: PropTypes.number,
 
     /**
      * The values to show in the info box. This is an array of
@@ -814,5 +820,6 @@ BoxChart.defaultProps = {
     },
     markerRadius: 2,
     infoWidth: 90,
-    infoHeight: 30
+    infoHeight: 30,
+    infoOffsetY: 20
 };

--- a/src/components/ChartRow.js
+++ b/src/components/ChartRow.js
@@ -99,9 +99,10 @@ export default class ChartRow extends React.Component {
         (_.has(child.props, "min") && _.has(child.props, "max"));
 
     updateScales(props) {
-        const innerHeight = +this.props.height - AXIS_MARGIN * 2;
-        const rangeTop = AXIS_MARGIN;
-        const rangeBottom = innerHeight - AXIS_MARGIN;
+        const axisMargin = props.axisMargin;
+        const innerHeight = +props.height - axisMargin * 2;
+        const rangeTop = axisMargin;
+        const rangeBottom = innerHeight - axisMargin;
         React.Children.forEach(props.children, child => {
             if (child === null) return;
             if (this.isChildYAxis(child)) {
@@ -166,7 +167,7 @@ export default class ChartRow extends React.Component {
         const axes = []; // Contains all the yAxis elements used in the render
         const chartList = []; // Contains all the Chart elements used in the render
         // Dimensions
-        const innerHeight = +this.props.height - AXIS_MARGIN * 2;
+        const innerHeight = +this.props.height - this.props.axisMargin * 2;
 
         //
         // Build a map of elements that occupy left or right slots next to the
@@ -473,6 +474,7 @@ ChartRow.defaultProps = {
     trackerTimeFormat: "%b %d %Y %X",
     enablePanZoom: false,
     height: 100,
+    axisMargin: 5,
     visible: true
 };
 
@@ -483,6 +485,12 @@ ChartRow.propTypes = {
     height: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 
     /**
+     * The vertical margin between the top and bottom of the row
+     * height and the top and bottom of the range of the chart.
+     */
+    axisMargin: PropTypes.number,
+
+    /**
      * Show or hide this row
      */
     visible: PropTypes.bool,
@@ -491,16 +499,19 @@ ChartRow.propTypes = {
      * Should the time be shown on top of the tracker info box
      */
     trackerShowTime: PropTypes.bool,
+
     /**
      * The width of the tracker info box
      */
     trackerInfoWidth: PropTypes.number,
+
     /**
      * The height of the tracker info box
      */
     trackerInfoHeight: PropTypes.number,
+
     /**
-     * Info box value or values to place next to the tracker line
+     * Info box value or values to place next to the tracker line.
      * This is either an array of objects, with each object
      * specifying the label (a string) and value (also a string)
      * to be shown in the info box, or a simple string label.
@@ -530,6 +541,7 @@ ChartRow.propTypes = {
      * Specify the styling of the chart row's title
      */
     titleStyle: PropTypes.object,
+
     /**
      * Specify the styling of the box behind chart row's title
      */

--- a/src/components/ChartRow.js
+++ b/src/components/ChartRow.js
@@ -22,8 +22,6 @@ import MultiBrush from "./MultiBrush";
 import TimeMarker from "./TimeMarker";
 import ScaleInterpolator from "../js/interpolators";
 
-const AXIS_MARGIN = 5;
-
 function createScale(yaxis, type, min, max, y0, y1) {
     let scale;
     if (_.isUndefined(min) || _.isUndefined(max)) {

--- a/src/components/EventMarker.js
+++ b/src/components/EventMarker.js
@@ -184,6 +184,7 @@ export default class EventMarker extends React.Component {
         // order to display them side by side.
         const posx = this.props.timeScale(t) + this.props.offsetX;
         const posy = this.props.yScale(value) - this.props.offsetY;
+        const infoOffsetY = this.props.infoOffsetY;
 
         const infoBoxProps = {
             align: "left",
@@ -286,7 +287,7 @@ export default class EventMarker extends React.Component {
                             x1={-10}
                             y1={lineBottom}
                             x2={-10}
-                            y2={20}
+                            y2={infoOffsetY}
                         />
                     );
                     horizontalStem = (
@@ -294,9 +295,9 @@ export default class EventMarker extends React.Component {
                             pointerEvents="none"
                             style={this.props.stemStyle}
                             x1={-10}
-                            y1={20}
+                            y1={infoOffsetY}
                             x2={-2}
-                            y2={20}
+                            y2={infoOffsetY}
                         />
                     );
                 }
@@ -319,7 +320,7 @@ export default class EventMarker extends React.Component {
                             x1={w + 10}
                             y1={lineBottom}
                             x2={w + 10}
-                            y2={20}
+                            y2={infoOffsetY}
                         />
                     );
                     horizontalStem = (
@@ -327,9 +328,9 @@ export default class EventMarker extends React.Component {
                             pointerEvents="none"
                             style={this.props.stemStyle}
                             x1={w + 10}
-                            y1={20}
+                            y1={infoOffsetY}
                             x2={w + 2}
-                            y2={20}
+                            y2={infoOffsetY}
                         />
                     );
                 }
@@ -350,8 +351,8 @@ export default class EventMarker extends React.Component {
                     {verticalStem}
                     {horizontalStem}
                     {dot}
-                    {this.renderTime(event)}
-                    <g transform={`translate(0,${this.props.offsetInfoBox})`}>{infoBox}</g>
+                    <g transform={`translate(0,${infoOffsetY - 20})`}>{this.renderTime(event)}</g>
+                    <g transform={`translate(0,${infoOffsetY})`}>{infoBox}</g>
                 </g>
             );
         }
@@ -463,9 +464,10 @@ EventMarker.propTypes = {
     offsetY: PropTypes.number,
 
     /**
-     * Offset the infobox position in the y direction
+     * The vertical offset in pixels of the EventMarker info box from the
+     * top of the chart. The default is 20.
      */
-    offsetInfoBox: PropTypes.number,
+    infoOffsetY: PropTypes.number,
 
     /**
      * [Internal] The timeScale supplied by the surrounding ChartContainer
@@ -509,5 +511,5 @@ EventMarker.defaultProps = {
     },
     offsetX: 0,
     offsetY: 0,
-    offsetInfoBox: 20
+    infoOffsetY: 20
 };

--- a/src/components/ScatterChart.js
+++ b/src/components/ScatterChart.js
@@ -394,6 +394,12 @@ ScatterChart.propTypes = {
     infoHeight: PropTypes.number, // eslint-disable-line
 
     /**
+     * The vertical offset in pixels of the EventMarker info box from the
+     * top of the chart.
+     */
+    infoOffsetY: PropTypes.number,
+
+    /**
      * The values to show in the info box. This is an array of
      * objects, with each object specifying the label and value
      * to be shown in the info box.
@@ -481,5 +487,6 @@ ScatterChart.defaultProps = {
         fill: "#999"
     },
     infoWidth: 90,
-    infoHeight: 30
+    infoHeight: 30,
+    infoOffsetY: 20
 };

--- a/src/website/packages/charts/api/docs.json
+++ b/src/website/packages/charts/api/docs.json
@@ -827,7 +827,7 @@
           }
         },
         "required": false,
-        "description": "A list of columns within the series that will be stacked on top of each other\n\nNOTE : Columns can't have periods because periods \nrepresent a path to deep data in the underlying events \n(i.e. reference into nested data structures)",
+        "description": "A list of columns within the series that will be stacked on top of each other\n\nNOTE : Columns can't have periods because periods\nrepresent a path to deep data in the underlying events\n(i.e. reference into nested data structures)",
         "defaultValue": {
           "value": "[\"value\"]",
           "computed": false
@@ -913,6 +913,17 @@
         "description": "The height of the info box",
         "defaultValue": {
           "value": "30",
+          "computed": false
+        }
+      },
+      "infoOffsetY": {
+        "type": {
+          "name": "number"
+        },
+        "required": false,
+        "description": "The vertical offset in pixels of the EventMarker info box from the\ntop of the chart.",
+        "defaultValue": {
+          "value": "20",
           "computed": false
         }
       },
@@ -1267,7 +1278,7 @@
           "name": "string"
         },
         "required": false,
-        "description": "The column within the TimeSeries to plot. Unlike other charts, the BoxChart\nworks on just a single column.\n\nNOTE : Columns can't have periods because periods \nrepresent a path to deep data in the underlying events \n(i.e. reference into nested data structures)",
+        "description": "The column within the TimeSeries to plot. Unlike other charts, the BoxChart\nworks on just a single column.\n\nNOTE : Columns can't have periods because periods\nrepresent a path to deep data in the underlying events\n(i.e. reference into nested data structures)",
         "defaultValue": {
           "value": "\"value\"",
           "computed": false
@@ -1359,6 +1370,17 @@
         "description": "The height of the hover info box",
         "defaultValue": {
           "value": "30",
+          "computed": false
+        }
+      },
+      "infoOffsetY": {
+        "type": {
+          "name": "number"
+        },
+        "required": false,
+        "description": "The vertical offset in pixels of the EventMarker info box from the\ntop of the chart.",
+        "defaultValue": {
+          "value": "20",
           "computed": false
         }
       },
@@ -1722,6 +1744,22 @@
         "returns": null
       },
       {
+        "name": "handleContextMenu",
+        "docblock": null,
+        "modifiers": [],
+        "params": [
+          {
+            "name": "x",
+            "type": null
+          },
+          {
+            "name": "y",
+            "type": null
+          }
+        ],
+        "returns": null
+      },
+      {
         "name": "handleBackgroundClick",
         "docblock": null,
         "modifiers": [],
@@ -2020,6 +2058,13 @@
         "required": false,
         "description": "Called when the user clicks the background plane of the chart. This is\nuseful when deselecting elements."
       },
+      "onContextMenu": {
+        "type": {
+          "name": "func"
+        },
+        "required": false,
+        "description": "Called when the user context-clicks the chart"
+      },
       "padding": {
         "type": {
           "name": "number"
@@ -2192,6 +2237,17 @@
           "computed": false
         }
       },
+      "axisMargin": {
+        "type": {
+          "name": "number"
+        },
+        "required": false,
+        "description": "The vertical margin between the top and bottom of the row\nheight and the top and bottom of the range of the chart.",
+        "defaultValue": {
+          "value": "5",
+          "computed": false
+        }
+      },
       "visible": {
         "type": {
           "name": "bool"
@@ -2250,7 +2306,35 @@
           ]
         },
         "required": false,
-        "description": "Info box value or values to place next to the tracker line\nThis is either an array of objects, with each object\nspecifying the label (a string) and value (also a string)\nto be shown in the info box, or a simple string label."
+        "description": "Info box value or values to place next to the tracker line.\nThis is either an array of objects, with each object\nspecifying the label (a string) and value (also a string)\nto be shown in the info box, or a simple string label."
+      },
+      "title": {
+        "type": {
+          "name": "string"
+        },
+        "required": false,
+        "description": "Specify the title for the chart row"
+      },
+      "titleHeight": {
+        "type": {
+          "name": "number"
+        },
+        "required": false,
+        "description": "Specify the height of the title\nDefault value is 28 pixels"
+      },
+      "titleStyle": {
+        "type": {
+          "name": "object"
+        },
+        "required": false,
+        "description": "Specify the styling of the chart row's title"
+      },
+      "titleBoxStyle": {
+        "type": {
+          "name": "object"
+        },
+        "required": false,
+        "description": "Specify the styling of the box behind chart row's title"
       },
       "children": {
         "type": {
@@ -2612,6 +2696,18 @@
           }
         ],
         "returns": null
+      },
+      {
+        "name": "handleContextMenu",
+        "docblock": null,
+        "modifiers": [],
+        "params": [
+          {
+            "name": "e",
+            "type": null
+          }
+        ],
+        "returns": null
       }
     ],
     "props": {
@@ -2726,6 +2822,13 @@
         },
         "required": false,
         "description": ""
+      },
+      "onContextMenu": {
+        "type": {
+          "name": "func"
+        },
+        "required": false,
+        "description": ""
       }
     }
   },
@@ -2814,7 +2917,7 @@
           "name": "string"
         },
         "required": false,
-        "description": "Which column in the Event to use\n\nNOTE : Columns can't have periods because periods \nrepresent a path to deep data in the underlying events \n(i.e. reference into nested data structures)",
+        "description": "Which column in the Event to use\n\nNOTE : Columns can't have periods because periods\nrepresent a path to deep data in the underlying events\n(i.e. reference into nested data structures)",
         "defaultValue": {
           "value": "\"value\"",
           "computed": false
@@ -2973,6 +3076,17 @@
         "description": "Offset the marker position in the y direction",
         "defaultValue": {
           "value": "0",
+          "computed": false
+        }
+      },
+      "infoOffsetY": {
+        "type": {
+          "name": "number"
+        },
+        "required": false,
+        "description": "The vertical offset in pixels of the EventMarker info box from the\ntop of the chart. The default is 20.",
+        "defaultValue": {
+          "value": "20",
           "computed": false
         }
       },
@@ -4219,7 +4333,7 @@
           }
         },
         "required": false,
-        "description": "Which columns of the series to render\n\nNOTE : Columns can't have periods because periods \nrepresent a path to deep data in the underlying events \n(i.e. reference into nested data structures)",
+        "description": "Which columns of the series to render\n\nNOTE : Columns can't have periods because periods\nrepresent a path to deep data in the underlying events\n(i.e. reference into nested data structures)",
         "defaultValue": {
           "value": "[\"value\"]",
           "computed": false
@@ -4310,6 +4424,17 @@
         "description": "The height of the hover info box",
         "defaultValue": {
           "value": "30",
+          "computed": false
+        }
+      },
+      "infoOffsetY": {
+        "type": {
+          "name": "number"
+        },
+        "required": false,
+        "description": "The vertical offset in pixels of the EventMarker info box from the\ntop of the chart.",
+        "defaultValue": {
+          "value": "20",
           "computed": false
         }
       },
@@ -4925,7 +5050,7 @@
           ]
         },
         "required": false,
-        "description": "",
+        "description": "Where to position the label, either \"left\" or \"center\" within the box",
         "defaultValue": {
           "value": "\"center\"",
           "computed": false
@@ -4964,7 +5089,7 @@
           "name": "object"
         },
         "required": false,
-        "description": "CSS object to be applied to the ValueList surrounding box",
+        "description": "CSS object to be applied to the ValueList surrounding box and the label (text).",
         "defaultValue": {
           "value": "{ fill: \"#FEFEFE\", stroke: \"#DDD\", opacity: 0.8 }",
           "computed": false
@@ -5073,6 +5198,22 @@
           {
             "name": "scale",
             "type": null
+          },
+          {
+            "name": "height",
+            "type": null
+          },
+          {
+            "name": "tickCount",
+            "type": null
+          },
+          {
+            "name": "min",
+            "type": null
+          },
+          {
+            "name": "max",
+            "type": null
           }
         ],
         "returns": null
@@ -5121,6 +5262,22 @@
           {
             "name": "fmt",
             "type": null
+          },
+          {
+            "name": "label",
+            "type": null
+          },
+          {
+            "name": "tickCount",
+            "type": null
+          },
+          {
+            "name": "min",
+            "type": null
+          },
+          {
+            "name": "max",
+            "type": null
           }
         ],
         "returns": null
@@ -5168,6 +5325,34 @@
           },
           {
             "name": "fmt",
+            "type": null
+          },
+          {
+            "name": "label",
+            "type": null
+          },
+          {
+            "name": "tickCount",
+            "type": null
+          },
+          {
+            "name": "min",
+            "type": null
+          },
+          {
+            "name": "max",
+            "type": null
+          }
+        ],
+        "returns": null
+      },
+      {
+        "name": "updateLabel",
+        "docblock": null,
+        "modifiers": [],
+        "params": [
+          {
+            "name": "label",
             "type": null
           }
         ],

--- a/src/website/packages/charts/examples/stockchart/Index.js
+++ b/src/website/packages/charts/examples/stockchart/Index.js
@@ -99,6 +99,7 @@ class stockchart extends React.Component {
                 hideWeekends={true}
                 enablePanZoom={true}
                 onTimeRangeChanged={this.handleTimeRangeChange}
+                timeAxisStyle={{ axis: { fill: "none", stroke: "none" } }}
             >
                 <ChartRow height="300">
                     <Charts>
@@ -120,7 +121,7 @@ class stockchart extends React.Component {
                         type={this.state.mode}
                     />
                 </ChartRow>
-                <ChartRow height="200">
+                <ChartRow height="200" axisMargin={0}>
                     <Charts>
                         <BarChart
                             axis="y"

--- a/src/website/packages/charts/examples/wind/Index.js
+++ b/src/website/packages/charts/examples/wind/Index.js
@@ -204,6 +204,7 @@ class wind extends React.Component {
                                             info={infoValues}
                                             infoHeight={28}
                                             infoWidth={110}
+                                            infoOffsetY={10}
                                             infoStyle={{
                                                 fill: "black",
                                                 color: "#DDD"


### PR DESCRIPTION
@chrisimmel

This work replicates the PR and rebases it with the latest code on master.

====
`Original PR Description`

This adds two new props for finer control of vertical spacing:

`EventMarker.infoOffsetY` controls the vertical offset in pixels of the EventMarker info box from the top of the chart. The default is 20px, the value that was previously hardcoded. The prop was also added to components that include EventMarker (BarChart, BoxChart, ScatterChart).

`ChartRow.axisMargin` controls the vertical margin between the top and bottom of the chart height and the top and bottom of the range of the chart. The default is 5px, the value that was previously hardcoded.

Sample usages were added to the existing stockchart and wind examples.

The motivation for these changes was a LineChart we have at Alluvium that is very squat. The hardcoded values for these parameters took too much vertical space in our use case. In particular, the default offset of the EventMarker info box placed it below the bottom edge of the chart.