### PR TITLE
fix: only set passive false on scroll wheel events

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,17 +1,19 @@
 # Changelog
 
-## v0.15.6
+## v0.16.0
 
-* Allow YAxis component label to be updated after initial render [PR #351](https://github.com/esnet/react-timeseries-charts/pull/351)
-* Update ChartRow to not call setState when unmounted [#246](https://github.com/esnet/react-timeseries-charts/issues/246)
-* Create a template for new issues
-* Add ability to specify the title of ChartRow [PR #359](https://github.com/esnet/react-timeseries-charts/pull/359)
-* Add customized text styling in ValueList.js [#355](https://github.com/esnet/react-timeseries-charts/issues/355)
-* Fix issue where the context menu triggers drag as well [#307](https://github.com/esnet/react-timeseries-charts/issues/307)
-* Fix for Chrome 73 default passive event listeners / Fix scrolling to zoom in a ChartContainer that also scrolls the entire page [#375](https://github.com/esnet/react-timeseries-charts/issues/375)
-* Fix for intermittently click event not working on EventChart [PR #369](https://github.com/esnet/react-timeseries-charts/pull/369)
-* Fix YAxis rerender on tickCount/min/max change [#371](https://github.com/esnet/react-timeseries-charts/issues/371)
-* Add options modify the vertical axis margin and vertical EventMarker infobox offset [PR #377](https://github.com/esnet/react-timeseries-charts/pull/377)
+> Mar 29, 2019
+
+-   Add ability to specify the title of ChartRow [PR #359](https://github.com/esnet/react-timeseries-charts/pull/359)
+-   Add customized text styling in ValueList.js [#355](https://github.com/esnet/react-timeseries-charts/issues/355)
+-   Fix YAxis component label not updating after initial render [PR #351](https://github.com/esnet/react-timeseries-charts/pull/351)
+-   Fix ChartRow so as to not call setState after being unmounted [#246](https://github.com/esnet/react-timeseries-charts/issues/246)
+-   Fix issue where the context menu triggers drag as well [#307](https://github.com/esnet/react-timeseries-charts/issues/307)
+-   Fix for Chrome 73 default passive event listeners / Fix scrolling to zoom in a ChartContainer that also scrolls the entire page [#375](https://github.com/esnet/react-timeseries-charts/issues/375)
+-   Fix for intermittently click event not working on EventChart [PR #369](https://github.com/esnet/react-timeseries-charts/pull/369)
+-   Fix YAxis rerender on tickCount/min/max change [#371](https://github.com/esnet/react-timeseries-charts/issues/371)
+-   Add options modify the vertical axis margin and vertical EventMarker infobox offset [PR #377](https://github.com/esnet/react-timeseries-charts/pull/377)
+-   Create a template for new issues
 
 ## v0.15.5
 
@@ -19,118 +21,118 @@
 
 Bug Fixes:
 
-* Update to create-react-app V2.0
-* Add note to documentation that columns can't have periods
-* Export BandChart component
-* Add an example to style BandChart component
-* Add a check for undefined value in the ScatterChart component
+-   Update to create-react-app V2.0
+-   Add note to documentation that columns can't have periods
+-   Export BandChart component
+-   Add an example to style BandChart component
+-   Add a check for undefined value in the ScatterChart component
 
 ## v0.15.4
 
 > Oct 26, 2018
 
-* Removes flexbox-react dependency [#310](https://github.com/esnet/react-timeseries-charts/issues/310)
-* Fixes Resizable component binding to `this` [#329](https://github.com/esnet/react-timeseries-charts/issues/329)
+-   Removes flexbox-react dependency [#310](https://github.com/esnet/react-timeseries-charts/issues/310)
+-   Fixes Resizable component binding to `this` [#329](https://github.com/esnet/react-timeseries-charts/issues/329)
 
 ## v0.15.3
 
 > Aug 15, 2018
 
-* Add feature to add style prop to `LabelAxis` component
-* Refactor `AreaChart` code
+-   Add feature to add style prop to `LabelAxis` component
+-   Refactor `AreaChart` code
 
 Bug fixes:
 
-* Corrects the wrong order for testing style type (Fixes [#277](https://github.com/esnet/react-timeseries-charts/issues/277))
-* Correctly stacking in area charts when some points are bad (Fixes [#284](https://github.com/esnet/react-timeseries-charts/issues/284))  
-* Adds prop to hide TimeAxis (Fixes [#295](https://github.com/esnet/react-timeseries-charts/issues/295))
-* Adds function argument while styling barcharts (Fixes [#291](https://github.com/esnet/react-timeseries-charts/issues/291))
-* Adds a prop `marginBottom` to the `Legend` component (Fixes [#243](https://github.com/esnet/react-timeseries-charts/issues/243))
-* Doesn't draw a `BarChart` when the height of the rectangle is 0 (Fixes [#294](https://github.com/esnet/react-timeseries-charts/issues/294))
-* Removes warnings on climate example (Fixes [#257](https://github.com/esnet/react-timeseries-charts/issues/257))
-* Exposes x, y and time value to onBackgroundClick method in `ChartContainer` (Fixes [#296](https://github.com/esnet/react-timeseries-charts/issues/296))
-* TimeMarker can be custom styled (Fixes [#304](https://github.com/esnet/react-timeseries-charts/issues/304))
-* Ability to style legend (Fixes [#112](https://github.com/esnet/react-timeseries-charts/issues/112))
+-   Corrects the wrong order for testing style type (Fixes [#277](https://github.com/esnet/react-timeseries-charts/issues/277))
+-   Correctly stacking in area charts when some points are bad (Fixes [#284](https://github.com/esnet/react-timeseries-charts/issues/284))
+-   Adds prop to hide TimeAxis (Fixes [#295](https://github.com/esnet/react-timeseries-charts/issues/295))
+-   Adds function argument while styling barcharts (Fixes [#291](https://github.com/esnet/react-timeseries-charts/issues/291))
+-   Adds a prop `marginBottom` to the `Legend` component (Fixes [#243](https://github.com/esnet/react-timeseries-charts/issues/243))
+-   Doesn't draw a `BarChart` when the height of the rectangle is 0 (Fixes [#294](https://github.com/esnet/react-timeseries-charts/issues/294))
+-   Removes warnings on climate example (Fixes [#257](https://github.com/esnet/react-timeseries-charts/issues/257))
+-   Exposes x, y and time value to onBackgroundClick method in `ChartContainer` (Fixes [#296](https://github.com/esnet/react-timeseries-charts/issues/296))
+-   TimeMarker can be custom styled (Fixes [#304](https://github.com/esnet/react-timeseries-charts/issues/304))
+-   Ability to style legend (Fixes [#112](https://github.com/esnet/react-timeseries-charts/issues/112))
 
 ## v0.15.0
 
 > May 22, 2018
 
-* Adds `YAxis` and `TimeAxis` styling of all elements. This is a breaking change, but now allows much more flexible styling. See the the DDoS example. In [#267](https://github.com/esnet/react-timeseries-charts/pull/267).
-* `YAxis` now supports horizontal grid lines. This only applies to axes which are adjacent to the chart (Fixes #244). In [#267](https://github.com/esnet/react-timeseries-charts/pull/267).
-* `TimeAxis` now supports angled labels [#229](https://github.com/esnet/react-timeseries-charts/pull/229)
-* You can now add a title to the chart by passing one into the `ChartContainer` (Fixes #9)
-* `AreaChart`s now have an option to break at data gaps (i.e. ignore `nulls` and `NaNs`) in [#247](https://github.com/esnet/react-timeseries-charts/pull/247)
-* `ChartContainer` now has a margin prop that will surround the chart with empty space. This is useful to avoid clipped `TimeAxis` labels [#229](https://github.com/esnet/react-timeseries-charts/pull/229)
-* Add drag to zoom feature by [@iabw](https://github.com/iabw) in [#252](https://github.com/esnet/react-timeseries-charts/pull/252)
-* Current `TimeAxis` scale function exposed as second argument to `onTrackerChanged()` by [@ethanroday](https://github.com/ethanroday) in [#238](https://github.com/esnet/react-timeseries-charts/pull/238)
-* Allow `YAxis` yscale by [@ethanroday](https://github.com/ethanroday) in [#251](https://github.com/esnet/react-timeseries-charts/pull/251)
+-   Adds `YAxis` and `TimeAxis` styling of all elements. This is a breaking change, but now allows much more flexible styling. See the the DDoS example. In [#267](https://github.com/esnet/react-timeseries-charts/pull/267).
+-   `YAxis` now supports horizontal grid lines. This only applies to axes which are adjacent to the chart (Fixes #244). In [#267](https://github.com/esnet/react-timeseries-charts/pull/267).
+-   `TimeAxis` now supports angled labels [#229](https://github.com/esnet/react-timeseries-charts/pull/229)
+-   You can now add a title to the chart by passing one into the `ChartContainer` (Fixes #9)
+-   `AreaChart`s now have an option to break at data gaps (i.e. ignore `nulls` and `NaNs`) in [#247](https://github.com/esnet/react-timeseries-charts/pull/247)
+-   `ChartContainer` now has a margin prop that will surround the chart with empty space. This is useful to avoid clipped `TimeAxis` labels [#229](https://github.com/esnet/react-timeseries-charts/pull/229)
+-   Add drag to zoom feature by [@iabw](https://github.com/iabw) in [#252](https://github.com/esnet/react-timeseries-charts/pull/252)
+-   Current `TimeAxis` scale function exposed as second argument to `onTrackerChanged()` by [@ethanroday](https://github.com/ethanroday) in [#238](https://github.com/esnet/react-timeseries-charts/pull/238)
+-   Allow `YAxis` yscale by [@ethanroday](https://github.com/ethanroday) in [#251](https://github.com/esnet/react-timeseries-charts/pull/251)
 
 Bug fixes:
 
-* `TimeAxis` and `YAxis` now updates to additional prop changes (Fixes #259, Fixes #255 )
-* Ease required props on `TimeRangeMarker` (Fixes #263)
-* `ChartRow` is better protected against null children [#253](https://github.com/esnet/react-timeseries-charts/pull/253)
-* Fix issues with using webpack and hot loader in [#248](https://github.com/esnet/react-timeseries-charts/pull/248)
+-   `TimeAxis` and `YAxis` now updates to additional prop changes (Fixes #259, Fixes #255 )
+-   Ease required props on `TimeRangeMarker` (Fixes #263)
+-   `ChartRow` is better protected against null children [#253](https://github.com/esnet/react-timeseries-charts/pull/253)
+-   Fix issues with using webpack and hot loader in [#248](https://github.com/esnet/react-timeseries-charts/pull/248)
 
 ## v0.14.0
 
 > March 2, 2018
 
-* Add MultiBrush component and update traffic example to implement the same [@barbaragomes](https://github.com/barbaragomes) in [#224](https://github.com/esnet/react-timeseries-charts/pull/224)
-* Add a crosshairs custom chart to the currency demo
-* Ability to ignore null points in ScatterChart [#226]
-* Exposes hover x,y events in ChartContainer handleMouseMove [#199]
-* Added a control for TimeAxis tick count [#220]
-* Control minimum BarChart height [#218]
-* Fixed LineChart example text [#215]
-* Baseline has better control over label vertical positioning [#216]
-* Legend horizontal layout now wraps automatically [#202]
-* Legend can now be laid out in a column (see weather example)
-* Legend items can specify the symbol type
-* ScatterChart now ignores null points [#197]
-* YAxis tick count improvements [#175]
-* Emit warning when using a log scale with min set to 0 [#45]
+-   Add MultiBrush component and update traffic example to implement the same [@barbaragomes](https://github.com/barbaragomes) in [#224](https://github.com/esnet/react-timeseries-charts/pull/224)
+-   Add a crosshairs custom chart to the currency demo
+-   Ability to ignore null points in ScatterChart [#226]
+-   Exposes hover x,y events in ChartContainer handleMouseMove [#199]
+-   Added a control for TimeAxis tick count [#220]
+-   Control minimum BarChart height [#218]
+-   Fixed LineChart example text [#215]
+-   Baseline has better control over label vertical positioning [#216]
+-   Legend horizontal layout now wraps automatically [#202]
+-   Legend can now be laid out in a column (see weather example)
+-   Legend items can specify the symbol type
+-   ScatterChart now ignores null points [#197]
+-   YAxis tick count improvements [#175]
+-   Emit warning when using a log scale with min set to 0 [#45]
 
 ## v0.13.1
 
 > January 29, 2018
 
-* Support for React 16
-* Ability to hide and show charts, rows and axes with a single flag
-* Ability to supply format function to y-axis scales ([@ethanroday](https://github.com/ethanroday) in [#211](https://github.com/esnet/react-timeseries-charts/pull/212))
+-   Support for React 16
+-   Ability to hide and show charts, rows and axes with a single flag
+-   Ability to supply format function to y-axis scales ([@ethanroday](https://github.com/ethanroday) in [#211](https://github.com/esnet/react-timeseries-charts/pull/212))
 
 ## v0.12.6
 
 > July 14, 2017
 
-* Improves formatting option to the time axis, it can either be a d3 time format string or a callback function (#86, #164)
-* Cleanup of formatting code, and mirror change into the TimeTracker code so that it works the same. (#164).
-* Fixes the undefined time that would sometimes be seen above the tracker info box (#147)
-* Fixes issue where the format specified on the ChartContainer would become stale (#140)
-* Fixes problem when the brush would get stuck if fully expanded (#141)
-* Adds ability to control the tick size (#150)
-* Docs provide link to source code for examples (#133)
+-   Improves formatting option to the time axis, it can either be a d3 time format string or a callback function (#86, #164)
+-   Cleanup of formatting code, and mirror change into the TimeTracker code so that it works the same. (#164).
+-   Fixes the undefined time that would sometimes be seen above the tracker info box (#147)
+-   Fixes issue where the format specified on the ChartContainer would become stale (#140)
+-   Fixes problem when the brush would get stuck if fully expanded (#141)
+-   Adds ability to control the tick size (#150)
+-   Docs provide link to source code for examples (#133)
 
 ## v0.12.5
 
 > Jun 15, 2017
 
-* Fixes React propType warnings by using prop-types package ([@aruntk](https://github.com/aruntka) in [#152](https://github.com/esnet/react-timeseries-charts/pull/152))
-* Fixes an issue with ScatterChart prop type ([@christian-acuna](https://github.com/christian-acuna) in [#155](https://github.com/esnet/react-timeseries-charts/pull/155))
-* Pointer events allowing on ScatterChart ([@samford100](https://github.com/samford100) in [#137](https://github.com/esnet/react-timeseries-charts/pull/137))
+-   Fixes React propType warnings by using prop-types package ([@aruntk](https://github.com/aruntka) in [#152](https://github.com/esnet/react-timeseries-charts/pull/152))
+-   Fixes an issue with ScatterChart prop type ([@christian-acuna](https://github.com/christian-acuna) in [#155](https://github.com/esnet/react-timeseries-charts/pull/155))
+-   Pointer events allowing on ScatterChart ([@samford100](https://github.com/samford100) in [#137](https://github.com/esnet/react-timeseries-charts/pull/137))
 
 ## v0.12.3
 
 > Feb 24, 2017
 
-* Fixes issue where the `BoxChart` is not re-rendering on `TimeSeries` change ([#126](https://github.com/esnet/react-timeseries-charts/pull/126)))
+-   Fixes issue where the `BoxChart` is not re-rendering on `TimeSeries` change ([#126](https://github.com/esnet/react-timeseries-charts/pull/126)))
 
 ## v0.12.1
 
 > Feb 24, 2017
 
-* Fixed default color for BoxChart infoBox
+-   Fixed default color for BoxChart infoBox
 
 ## v0.12.0
 
@@ -138,30 +140,30 @@ Bug fixes:
 
 **Dependency updates:**
 
-* Update to latest version of d3 dependencies (i.e. v1.0 releases)
-* Updates peer dependency to Pond 0.8.x. If you use Pond directly, especially events, there are some breaking changes in this version. Of particular note: `new Event()` is likely now `new TimeEvent()`. Static methods are still on the base class `Event`, however.
+-   Update to latest version of d3 dependencies (i.e. v1.0 releases)
+-   Updates peer dependency to Pond 0.8.x. If you use Pond directly, especially events, there are some breaking changes in this version. Of particular note: `new Event()` is likely now `new TimeEvent()`. Static methods are still on the base class `Event`, however.
 
 **Enhancements and API changes**
 
-* `EventMarker`s now support a simple label attached to the marker, in addition to the flag style marker seen in the tracker. This allows some new options for annotations.
+-   `EventMarker`s now support a simple label attached to the marker, in addition to the flag style marker seen in the tracker. This allows some new options for annotations.
 
 ![markers](https://cloud.githubusercontent.com/assets/1288813/23275412/4c24c3b0-f9bb-11e6-9ca6-d45a44f7613f.gif)
 
-* Charts no longer need a corresponding axis if you pass in the `yScale` directly (or if the chart doesn't need a y scale at all). This is nice for overlaying errors, or making an `EventChart` without having to create a bogus y-scale.
-* Change to `Legend` to clean up that code: props `width` and `height` are now `symbolWidth` and `symbolHeight`, which is clearer about what they do.
-* `EventMarker` `infoStyle` (and use within `BarCharts` and `ScatterCharts`) is broken into `infoStyle` (for the infoBox), `stemStyle` and `markerStyle`.
-* `LineCharts` or `ScatterChart` of `IndexedEvent`s or `TimeRangeEvent`s plot points in the center of their time range, not the beginning as they did before. This way markers do not have to take this into account.
+-   Charts no longer need a corresponding axis if you pass in the `yScale` directly (or if the chart doesn't need a y scale at all). This is nice for overlaying errors, or making an `EventChart` without having to create a bogus y-scale.
+-   Change to `Legend` to clean up that code: props `width` and `height` are now `symbolWidth` and `symbolHeight`, which is clearer about what they do.
+-   `EventMarker` `infoStyle` (and use within `BarCharts` and `ScatterCharts`) is broken into `infoStyle` (for the infoBox), `stemStyle` and `markerStyle`.
+-   `LineCharts` or `ScatterChart` of `IndexedEvent`s or `TimeRangeEvent`s plot points in the center of their time range, not the beginning as they did before. This way markers do not have to take this into account.
 
 **Bug fixes:**
 
-* Disable all mouse pan/zoom related event handling when `enablePanZoom=false` ([#121](https://github.com/esnet/react-timeseries-charts/pull/121)) and [#96](https://github.com/esnet/react-timeseries-charts/pull/96)))
-* Fixes bug resulting in stale format in `TimeAxis` (Fixes [#128](https://github.com/esnet/react-timeseries-charts/pull/128)))
-* Missing propType in `YAxis`
+-   Disable all mouse pan/zoom related event handling when `enablePanZoom=false` ([#121](https://github.com/esnet/react-timeseries-charts/pull/121)) and [#96](https://github.com/esnet/react-timeseries-charts/pull/96)))
+-   Fixes bug resulting in stale format in `TimeAxis` (Fixes [#128](https://github.com/esnet/react-timeseries-charts/pull/128)))
+-   Missing propType in `YAxis`
 
 **Website changes:**
 
-* Adds babel-polyfill import to the examples page for IE support (untested) (Fixes [#111](https://github.com/esnet/react-timeseries-charts/pull/111)))
-* `BarChart` docs improvements: new simple example and better explanation of `IndexedEvent` requirement in API docs. ([#125](https://github.com/esnet/react-timeseries-charts/pull/125)))
+-   Adds babel-polyfill import to the examples page for IE support (untested) (Fixes [#111](https://github.com/esnet/react-timeseries-charts/pull/111)))
+-   `BarChart` docs improvements: new simple example and better explanation of `IndexedEvent` requirement in API docs. ([#125](https://github.com/esnet/react-timeseries-charts/pull/125)))
 
 <img width="1090" alt="screen shot 2017-02-23 at 11 24 19 am" src="https://cloud.githubusercontent.com/assets/1288813/23275473/809f3fda-f9bb-11e6-8060-5ade2eb58d20.png">
 
@@ -169,14 +171,14 @@ Bug fixes:
 
 > Feb 6, 2017
 
-* Fixes `infoTimeFormat` prop to work with BarCharts, so you can now format an IndexedEvent (#120)
-* Fixes missing curveMonotone curve type (now curveMonotoneX and curveMonotoneY) since the d3 API changed (#114)
+-   Fixes `infoTimeFormat` prop to work with BarCharts, so you can now format an IndexedEvent (#120)
+-   Fixes missing curveMonotone curve type (now curveMonotoneX and curveMonotoneY) since the d3 API changed (#114)
 
 ## v0.11.1
 
 > Dec 1, 2016
 
-* Fixes bad proptype in TimeRangeMarker (#107)
+-   Fixes bad proptype in TimeRangeMarker (#107)
 
 ## v0.11.0
 
@@ -184,35 +186,35 @@ Bug fixes:
 
 **New**
 
-* Adds a BoxChart chart. This is the first chart to enable automatic aggregations. More to come.
-* Adds a BoxChart example showing temperature ranges in NYC
-* Adds a BoxChart example to the existing cycling example, which shows how to do roll-ups directly on a TimeSeries to produce the summary BoxChart
-* Adds an example showing NASA global temperature data
+-   Adds a BoxChart chart. This is the first chart to enable automatic aggregations. More to come.
+-   Adds a BoxChart example showing temperature ranges in NYC
+-   Adds a BoxChart example to the existing cycling example, which shows how to do roll-ups directly on a TimeSeries to produce the summary BoxChart
+-   Adds an example showing NASA global temperature data
 
 **Enhancements**
 
-* BarChart: Support for negative values ([@jverhoeven](https://github.com/jverhoeven) in [#95](https://github.com/esnet/react-timeseries-charts/pull/95))
-* EventChart: Can now set text label position and hover marker width ([@primozs](https://github.com/primozs) in [#104](https://github.com/esnet/react-timeseries-charts/pull/104))
-* EventChart: Separate events for hover: onMouseOver and onMouseLeave replace onMouseMove ([@primozs](https://github.com/primozs) in [#104](https://github.com/esnet/react-timeseries-charts/pull/104))
-* Brush: Adds a callback for `onTimeRangeSelectComplete` ([@viky293](https://github.com/viky293) in [#91](https://github.com/esnet/react-timeseries-charts/pull/91))
+-   BarChart: Support for negative values ([@jverhoeven](https://github.com/jverhoeven) in [#95](https://github.com/esnet/react-timeseries-charts/pull/95))
+-   EventChart: Can now set text label position and hover marker width ([@primozs](https://github.com/primozs) in [#104](https://github.com/esnet/react-timeseries-charts/pull/104))
+-   EventChart: Separate events for hover: onMouseOver and onMouseLeave replace onMouseMove ([@primozs](https://github.com/primozs) in [#104](https://github.com/esnet/react-timeseries-charts/pull/104))
+-   Brush: Adds a callback for `onTimeRangeSelectComplete` ([@viky293](https://github.com/viky293) in [#91](https://github.com/esnet/react-timeseries-charts/pull/91))
 
 **Bug fixes**
 
-* EventChart: Fixes errors on pan/zoom ([@primozs](https://github.com/primozs) in [#102](https://github.com/esnet/react-timeseries-charts/pull/102))
-* Styler now correctly falls back to defaults for LineCharts, BarCharts and ScatterCharts ([@siavelis](https://github.com/siavelis) in [#103](https://github.com/esnet/react-timeseries-charts/pull/103))
+-   EventChart: Fixes errors on pan/zoom ([@primozs](https://github.com/primozs) in [#102](https://github.com/esnet/react-timeseries-charts/pull/102))
+-   Styler now correctly falls back to defaults for LineCharts, BarCharts and ScatterCharts ([@siavelis](https://github.com/siavelis) in [#103](https://github.com/esnet/react-timeseries-charts/pull/103))
 
 **General**
 
-* Removes the HorizontalBarChart, which now lives at react-timeseries-barchart to keep the library better focused
-* Overhaul of linting rules. Uses AirBnB, almost. But not all examples are converted yet :(
-* More complete use of propTypes
-* Better API docs
+-   Removes the HorizontalBarChart, which now lives at react-timeseries-barchart to keep the library better focused
+-   Overhaul of linting rules. Uses AirBnB, almost. But not all examples are converted yet :(
+-   More complete use of propTypes
+-   Better API docs
 
 ## v0.10.1
 
 > Sep 15, 2016
 
-* Fix AreaChart default style (#79)
+-   Fix AreaChart default style (#79)
 
 ## v0.10.0
 
@@ -220,32 +222,32 @@ Bug fixes:
 
 **General**
 
-* The main theme of this release is styling improvements (#57), and this presents the only significant breaking change. Pretty much all styles have at least changed format. Additionally there's a `styler` object that can simplify defining styles across the API. See the [Styling Guide](https://github.com/esnet/react-timeseries-charts/blob/master/src/website/guides/style.md).
-* Overhaul of overlay markers. See the [Marker Guide](https://github.com/esnet/react-timeseries-charts/blob/master/src/website/guides/markers.md).
-* Selection and highlighting supported across the API.
-* Pond v0.7 is now a peer dependency.
-* React 15 and 0.14 are now both supported.
-* Support for UTC time axis scales.
-* Overhaul of example pages (now build on create-react-app).
+-   The main theme of this release is styling improvements (#57), and this presents the only significant breaking change. Pretty much all styles have at least changed format. Additionally there's a `styler` object that can simplify defining styles across the API. See the [Styling Guide](https://github.com/esnet/react-timeseries-charts/blob/master/src/website/guides/style.md).
+-   Overhaul of overlay markers. See the [Marker Guide](https://github.com/esnet/react-timeseries-charts/blob/master/src/website/guides/markers.md).
+-   Selection and highlighting supported across the API.
+-   Pond v0.7 is now a peer dependency.
+-   React 15 and 0.14 are now both supported.
+-   Support for UTC time axis scales.
+-   Overhaul of example pages (now build on create-react-app).
 
 **Bugfixes**
 
-* Handle background selection clearing on the EventHandler rather than in the Scatter and BarChart code, so that these charts can be overlaid on top of each other without stealing each other's events.
-* Fixes use of array fill for older browsers (#71)
-* Fixes bad YAxis animations that sometimes finished in the wrong place (#77)
+-   Handle background selection clearing on the EventHandler rather than in the Scatter and BarChart code, so that these charts can be overlaid on top of each other without stealing each other's events.
+-   Fixes use of array fill for older browsers (#71)
+-   Fixes bad YAxis animations that sometimes finished in the wrong place (#77)
 
 ## v0.9.2
 
 > Jul 6, 2016
 
-* **Bugfix:** Fixes a bug where the LineChart wouldn't render if the
-  breakLines prop was set to false (#65)
+-   **Bugfix:** Fixes a bug where the LineChart wouldn't render if the
+    breakLines prop was set to false (#65)
 
 ## v0.9.1
 
 > Jun 29, 2016
 
-* **Bugfix:** Update LineChart when the columns prop changes (#63)
+-   **Bugfix:** Update LineChart when the columns prop changes (#63)
 
 ## v0.9.0
 
@@ -253,86 +255,86 @@ Bug fixes:
 
 **New:**
 
-* Adds horizontal bar charts to compare a list of TimeSeries
-* Channel display of data using LabelAxis and ValueAxis (see cycling example)
+-   Adds horizontal bar charts to compare a list of TimeSeries
+-   Channel display of data using LabelAxis and ValueAxis (see cycling example)
 
 **General:**
 
-* Ability to show grid markers for the time axis. Add the prop `showGrid={true}` to the `<ChartContainer>`.
-* Changed event handling to be on top of the whole SVG charts area, rather than per row. This allows you to drag on the timeline or interact across rows. Drag now works if you drag off the SVG area, though it's slow on Chrome for some reason. But at least it doesn't interrupt the drag.
-* Better y-scale transitions. Transition time prop should now be specified on the YAxis itself rather than the ChartContainer.
-* Uses Pond 0.6.x, now specified as a peer dependency, so bring your own pondjs.
+-   Ability to show grid markers for the time axis. Add the prop `showGrid={true}` to the `<ChartContainer>`.
+-   Changed event handling to be on top of the whole SVG charts area, rather than per row. This allows you to drag on the timeline or interact across rows. Drag now works if you drag off the SVG area, though it's slow on Chrome for some reason. But at least it doesn't interrupt the drag.
+-   Better y-scale transitions. Transition time prop should now be specified on the YAxis itself rather than the ChartContainer.
+-   Uses Pond 0.6.x, now specified as a peer dependency, so bring your own pondjs.
 
 **AreaChart:**
 
-* Now supports full d3 interpolation set
-* Now supports outlining of the areas
+-   Now supports full d3 interpolation set
+-   Now supports outlining of the areas
 
 **LineChart:**
 
-* LineCharts are now implemented with d3 paths
-* Supports full interpolation set d3 offers
-* Line charts can now display multiple columns as separate paths using the `columns` prop.
-* Styling has changed to allow styling of the multiple paths and will accept a full CSS like object so you have complete control over the styling.
+-   LineCharts are now implemented with d3 paths
+-   Supports full interpolation set d3 offers
+-   Line charts can now display multiple columns as separate paths using the `columns` prop.
+-   Styling has changed to allow styling of the multiple paths and will accept a full CSS like object so you have complete control over the styling.
 
 **Legends:**
 
-* Expanded styling API lets you customize the swatch, dot or line
-* Now supports showing value under the legend label using "value" within the properties
-* Legends are now built with SVG rather than CSS applied to an element. This means the style required to make it work has also changed. Specifically, where you might have had `{backgroundColor: "red"}`, and you have a swatch, that would now be `{fill: "red"}` while if you have a line type legend item, that would be `{stroke: "red"}`. This enables complete control, but this breaks existing legends.
+-   Expanded styling API lets you customize the swatch, dot or line
+-   Now supports showing value under the legend label using "value" within the properties
+-   Legends are now built with SVG rather than CSS applied to an element. This means the style required to make it work has also changed. Specifically, where you might have had `{backgroundColor: "red"}`, and you have a swatch, that would now be `{fill: "red"}` while if you have a line type legend item, that would be `{stroke: "red"}`. This enables complete control, but this breaks existing legends.
 
 **Baselines:**
 
-* Styling for baselines. Use the `style` prop. See the baseline example for what
-  this style should look like.
+-   Styling for baselines. Use the `style` prop. See the baseline example for what
+    this style should look like.
 
 **Trackers and tooltips:**
 
-* The general charts tracker can now show the time, along with value properties under it
-* Specialized tooltip display for scatter charts
+-   The general charts tracker can now show the time, along with value properties under it
+-   Specialized tooltip display for scatter charts
 
 **Internal:**
 
-* Uses of broken apart d3 4.0 modules.
-* Brush is now implemented entirely in React, no more d3-brush
-* New component to display a list of (key, value) pairs in SVG is used for the LabelAxis and tooltips now
-* React based rendering for AreaChart and ScatterChart now
+-   Uses of broken apart d3 4.0 modules.
+-   Brush is now implemented entirely in React, no more d3-brush
+-   New component to display a list of (key, value) pairs in SVG is used for the LabelAxis and tooltips now
+-   React based rendering for AreaChart and ScatterChart now
 
 ## v0.8.1
 
 > Feb 10, 2016
 
-* **Bugfix:** Export Brush
+-   **Bugfix:** Export Brush
 
 ## v0.8.0
 
 > Feb 10, 2016
 
-* Adds d3 brush and examples
+-   Adds d3 brush and examples
 
 ## v0.7.0
 
 > Jan 13, 2016
 
-* Legend items can be enabled/disabled
-* Removes Bootstrap as a dependency. Entire chart row structure is one SVG object now.
-* Removed chart container css file, as it isn't needed anymore.
-* Added propTypes to ChartContainer.
-* Added tracker to ChartContainer rather than ChartRow so that it can be drawn across all rows at the same time.
-* Auto-generated docs.
-* Fixed some update issues when the width of the chart changed.
-* Fixed propTypes for the Table.
+-   Legend items can be enabled/disabled
+-   Removes Bootstrap as a dependency. Entire chart row structure is one SVG object now.
+-   Removed chart container css file, as it isn't needed anymore.
+-   Added propTypes to ChartContainer.
+-   Added tracker to ChartContainer rather than ChartRow so that it can be drawn across all rows at the same time.
+-   Auto-generated docs.
+-   Fixed some update issues when the width of the chart changed.
+-   Fixed propTypes for the Table.
 
 ## v0.6.0
 
 > Dec 4, 2015
 
-* Ability to have LineCharts break their line at bad values, or simply filter out those points. Fixes #30.
-* Ability to display a 'relative' time axis (0:00, 0:15, 0:30, 1hr, 1:15, ...). See screenshot below. Fixed #33.
-* Optimized updating of LineCharts (implements shouldComponentUpdate() now). Fixes #34.
+-   Ability to have LineCharts break their line at bad values, or simply filter out those points. Fixes #30.
+-   Ability to display a 'relative' time axis (0:00, 0:15, 0:30, 1hr, 1:15, ...). See screenshot below. Fixed #33.
+-   Optimized updating of LineCharts (implements shouldComponentUpdate() now). Fixes #34.
 
 ## v0.5.1
 
 > Nov 24, 2015
 
-* React 0.14
+-   React 0.14

--- a/lib/components/ChartRow.js
+++ b/lib/components/ChartRow.js
@@ -104,8 +104,6 @@ function _inherits(subClass, superClass) {
  *  LICENSE file in the root directory of this source tree.
  */
 
-var AXIS_MARGIN = 5;
-
 function createScale(yaxis, type, min, max, y0, y1) {
     var scale = void 0;
     if (_underscore2.default.isUndefined(min) || _underscore2.default.isUndefined(max)) {

--- a/src/components/EventHandler.js
+++ b/src/components/EventHandler.js
@@ -44,19 +44,7 @@ export default class EventHandler extends React.Component {
     }
 
     componentDidMount() {
-        const handlers = {
-            wheel: this.handleScrollWheel,
-            mousedown: this.handleMouseDown,
-            mousemove: this.handleMouseMove,
-            mouseout: this.handleMouseOut,
-            mouseup: this.handleMouseUp,
-            contextmenu: this.handleContextMenu
-        };
-
-        Object.keys(handlers).forEach(type => {
-            const handlerFunc = handlers[type];
-            this.eventHandlerRef.addEventListener(type, handlerFunc, { passive: false });
-        });
+        this.eventHandlerRef.addEventListener("wheel", this.handleScrollWheel, { passive: false });
     }
 
     // get the event mouse position relative to the event rect
@@ -304,13 +292,20 @@ export default class EventHandler extends React.Component {
 
     render() {
         const cursor = this.state.isPanning ? "-webkit-grabbing" : "default";
-
+        const handlers = {
+            onMouseDown: this.handleMouseDown,
+            onMouseMove: this.handleMouseMove,
+            onMouseOut: this.handleMouseOut,
+            onMouseUp: this.handleMouseUp,
+            onContextMenu: this.handleContextMenu
+        };
         return (
             <g
                 pointerEvents="all"
                 ref={c => {
                     this.eventHandlerRef = c;
                 }}
+                {...handlers}
             >
                 <rect
                     key="handler-hit-rect"


### PR DESCRIPTION
The previous change (https://github.com/esnet/react-timeseries-charts/pull/376) broke event propagation causing the MultiBrush (traffic) example to stop working correctly. Just putting this fix onto the scroll event seems to fix the page scrolls when zooming a chart issue, along with the chrome error messages.

Note: the only important file for the passive handler change is EventHandler.js (but the CHANGELOG is also updated in this PR for @sartaj10 to check over).

cc: @igozali 