### PR TITLE
fix: run prettier only on src dir in commit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "precommit": "lint-staged"
   },
   "lint-staged": {
-    "*.js": [
-      "prettier --print-width 100 --tab-width 4 --write",
+    "src/**/*.js": [
+      "prettier --print-width 100 --tab-width 4 --write 'src/**/*.js'",
       "git add"
     ]
   },


### PR DESCRIPTION
this was breaking the docs build, see #201 for details

This is a pretty simple change, but I want to be sure that it's ok that we only run prettier on the src directory.

This, in combination with regenerating the docs fixes #201.