### PR TITLE
pass trackerValues thru to infoValues

### DIFF
--- a/lib/components/ChartContainer.js
+++ b/lib/components/ChartContainer.js
@@ -480,13 +480,13 @@ var ChartContainer = function (_React$Component) {
                     _react2.default.createElement(_TimeMarker2.default, {
                         width: chartsWidth,
                         height: chartsHeight,
-                        showInfoBox: false,
+                        showInfoBox: !!this.props.trackerValues,
                         time: this.props.trackerPosition,
                         timeScale: timeScale,
                         timeFormat: this.props.format,
                         infoWidth: this.props.trackerHintWidth,
                         infoHeight: this.props.trackerHintHeight,
-                        info: this.props.trackerValues,
+                        infoValues: this.props.trackerValues,
                         infoStyle: trackerStyle
                     })
                 );

--- a/src/components/ChartContainer.js
+++ b/src/components/ChartContainer.js
@@ -424,13 +424,13 @@ export default class ChartContainer extends React.Component {
                     <TimeMarker
                         width={chartsWidth}
                         height={chartsHeight}
-                        showInfoBox={false}
+                        showInfoBox={!!this.props.trackerValues}
                         time={this.props.trackerPosition}
                         timeScale={timeScale}
                         timeFormat={this.props.format}
                         infoWidth={this.props.trackerHintWidth}
                         infoHeight={this.props.trackerHintHeight}
-                        info={this.props.trackerValues}
+                        infoValues={this.props.trackerValues}
                         infoStyle={trackerStyle}
                     />
                 </g>


### PR DESCRIPTION
before this patch, setting `trackerValues` on `ChartContainer` appears to do nothing.

i [described the issue in a comment](https://github.com/esnet/react-timeseries-charts/issues/353#issuecomment-493123331). the `info` prop doesn't exist at all on `TimeMarker`. 

---

the docs say this about `showInfoBox`:
```
    /**
     * Display the info box at all. If you don't have any values to show and just
     * want a line and a time (for example), you can set this to false.
     */
    showInfoBox: PropTypes.bool,
```

however, with `showInfoBox={false}`, i wouldn't see anything besides the line -- no time indicator or anything. maybe these docs are incorrect. 

setting `showInfoBox={!!this.props.trackerValues}` allows me to make use of `trackerValues`.