### PR TITLE
pass box/label styles thru to ValueList/Label

### DIFF
--- a/lib/components/ChartContainer.js
+++ b/lib/components/ChartContainer.js
@@ -744,6 +744,7 @@ ChartContainer.propTypes = {
      * When we use the TimeMarker as a tracker, we can style the box and dot as well.
      */
     trackerStyle: _propTypes2.default.shape({
+        label: _propTypes2.default.object, // eslint-disable-line
         line: _propTypes2.default.object, // eslint-disable-line
         box: _propTypes2.default.object, // eslint-disable-line
         dot: _propTypes2.default.object // eslint-disable-line

--- a/lib/components/TimeMarker.js
+++ b/lib/components/TimeMarker.js
@@ -113,7 +113,10 @@ var TimeMarker = function (_React$Component) {
 
             var infoBoxProps = {
                 align: "left",
-                style: this.props.infoStyle.box,
+                style: {
+                    box: this.props.infoStyle.box,
+                    label: this.props.infoStyle.label
+                },
                 width: this.props.infoWidth,
                 height: this.props.infoHeight
             };

--- a/src/components/ChartContainer.js
+++ b/src/components/ChartContainer.js
@@ -697,6 +697,7 @@ ChartContainer.propTypes = {
      * When we use the TimeMarker as a tracker, we can style the box and dot as well.
      */
     trackerStyle: PropTypes.shape({
+        label: PropTypes.object, // eslint-disable-line
         line: PropTypes.object, // eslint-disable-line
         box: PropTypes.object, // eslint-disable-line
         dot: PropTypes.object // eslint-disable-line

--- a/src/components/TimeMarker.js
+++ b/src/components/TimeMarker.js
@@ -70,7 +70,10 @@ export default class TimeMarker extends React.Component {
 
         const infoBoxProps = {
             align: "left",
-            style: this.props.infoStyle.box,
+            style: {
+                box: this.props.infoStyle.box,
+                label: this.props.infoStyle.label
+            },
             width: this.props.infoWidth,
             height: this.props.infoHeight
         };


### PR DESCRIPTION
without this patch, you can't style the `box`/`label` via `ChartContainer`'s `trackerStyle` prop.

with the way `mergeStyles` works in both `ValueList` and `Label`, the `style` prop expects both a `box` and `label` key. instead, `ChartContainer`'s `style.box` was getting passed thru directly as `style.

i think documentation and `defaultProps` need updated in a few places still.