### PR TITLE
Added the 'fill' property to ChartRow

### DIFF
--- a/lib/components/ChartRow.js
+++ b/lib/components/ChartRow.js
@@ -466,6 +466,15 @@ var ChartRow = function (_React$Component) {
             );
 
             //
+            // Fill
+            //
+            var fill = _react2.default.createElement(
+                "g",
+                { key: "fill-group", fill: this.props.fill },
+                this.props.fill != null ? _react2.default.createElement("rect", { x: "0", y: "0", width: this.props.width, height: innerHeight }) : null
+            );
+
+            //
             // Brush
             //
             var brushes = _react2.default.createElement(
@@ -520,6 +529,7 @@ var ChartRow = function (_React$Component) {
                 "g",
                 null,
                 clipper,
+                fill,
                 axes,
                 charts,
                 brushes,
@@ -614,5 +624,10 @@ ChartRow.propTypes = {
     timeScale: _propTypes2.default.func,
     trackerTimeFormat: _propTypes2.default.oneOfType([_propTypes2.default.string, _propTypes2.default.func]),
     timeFormat: _propTypes2.default.oneOfType([_propTypes2.default.string, _propTypes2.default.func]),
-    trackerTime: _propTypes2.default.instanceOf(Date)
+    trackerTime: _propTypes2.default.instanceOf(Date),
+
+    /**
+     * The fill of entire chart row.
+     */
+    fill: _propTypes2.default.string
 };

--- a/src/components/ChartRow.js
+++ b/src/components/ChartRow.js
@@ -405,6 +405,17 @@ export default class ChartRow extends React.Component {
         );
 
         //
+        // Fill
+        //
+        const fill = (
+            <g key="fill-group" fill={this.props.fill}>
+                {this.props.fill != null ? (
+                    <rect x="0" y="0" width={this.props.width} height={innerHeight} />
+                ) : null}
+            </g>
+        );
+
+        //
         // Brush
         //
         const brushes = (
@@ -458,6 +469,7 @@ export default class ChartRow extends React.Component {
         return (
             <g>
                 {clipper}
+                {fill}
                 {axes}
                 {charts}
                 {brushes}
@@ -552,5 +564,10 @@ ChartRow.propTypes = {
     timeScale: PropTypes.func,
     trackerTimeFormat: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
     timeFormat: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
-    trackerTime: PropTypes.instanceOf(Date)
+    trackerTime: PropTypes.instanceOf(Date),
+
+    /**
+     * The fill of entire chart row.
+     */
+    fill: PropTypes.string
 };

--- a/src/website/packages/charts/examples/weather/Index.js
+++ b/src/website/packages/charts/examples/weather/Index.js
@@ -178,7 +178,7 @@ class weather extends React.Component {
                                 trackerTimeFormat="%X"
                                 onTrackerChanged={tracker => this.setState({ tracker })}
                             >
-                                <ChartRow height="150">
+                                <ChartRow height="150" fill="ghostwhite">
                                     <YAxis
                                         id="pressure"
                                         label="Pressure (in)"


### PR DESCRIPTION
Added the ability to set fill of entire ChartRow.

The result looks like this (see `Weather` example):

![image](https://user-images.githubusercontent.com/3943804/61807495-534adb00-ae42-11e9-9821-d8e0d3d1ebaa.png)
