### PR TITLE
Passing style properties in the expected format down to the Label and ValueList components from the TimeMarker component

### DIFF
--- a/src/components/TimeMarker.js
+++ b/src/components/TimeMarker.js
@@ -70,7 +70,7 @@ export default class TimeMarker extends React.Component {
 
         const infoBoxProps = {
             align: "left",
-            style: this.props.infoStyle.box,
+            style: this.props.infoStyle,
             width: this.props.infoWidth,
             height: this.props.infoHeight
         };

--- a/src/website/packages/charts/examples/wind/Index.js
+++ b/src/website/packages/charts/examples/wind/Index.js
@@ -70,6 +70,7 @@ class wind extends React.Component {
         hover: null,
         highlight: null,
         selection: null,
+        tracker: null,
         timerange: series.range()
     };
 
@@ -163,13 +164,31 @@ class wind extends React.Component {
                             <ChartContainer
                                 timeRange={this.state.timerange}
                                 timeAxisStyle={timeAxisStyle}
+                                trackerPosition={this.state.tracker}
+                                trackerStyle={{
+                                    box: {
+                                        fill: "black",
+                                        color: "#DDD"
+                                    },
+                                    line: {
+                                        stroke: "red",
+                                        strokeDasharray: 2
+                                    }
+                                }}
                                 maxTime={series.range().end()}
                                 minTime={series.range().begin()}
                                 enablePanZoom={true}
                                 onBackgroundClick={() => this.setState({ selection: null })}
                                 onTimeRangeChanged={timerange => this.setState({ timerange })}
+                                onTrackerChanged={tracker => this.setState({ tracker })}
                             >
-                                <ChartRow height="150" debug={false}>
+                                <ChartRow
+                                    height="150"
+                                    debug={false}
+                                    trackerInfoWidth={125}
+                                    trackerInfoHeight={30}
+                                    trackerInfoValues={infoValues}
+                                >
                                     <YAxis
                                         id="wind-gust"
                                         label="Wind gust (mph)"
@@ -201,14 +220,14 @@ class wind extends React.Component {
                                             series={series}
                                             columns={["station1"]} // {["station1", "station2"]}
                                             style={perEventStyle}
-                                            info={infoValues}
-                                            infoHeight={28}
-                                            infoWidth={110}
-                                            infoOffsetY={10}
-                                            infoStyle={{
-                                                fill: "black",
-                                                color: "#DDD"
-                                            }}
+                                            // info={infoValues}
+                                            // infoHeight={28}
+                                            // infoWidth={110}
+                                            // infoOffsetY={10}
+                                            // infoStyle={{ box: {
+                                            //     fill: "black",
+                                            //     color: "#DDD"
+                                            // }}}
                                             format=".1f"
                                             selected={this.state.selection}
                                             onSelectionChange={p => this.handleSelectionChanged(p)}


### PR DESCRIPTION
Hello,

Just a quick PR to address a styling bug I came across while using the tracker.  The TimeMarker component passes the style property down to the Label and ValueList components in the the form of `this.props.infoStyle.box`.  Each of those components are expecting a `style.box` property to style the resulting box portion of the tracker display.  This was just a one-liner deletion from the `TimeMarker.js` file.

I mocked up an example of the fix using the "Scatter example" page. This can be discarded; just needed to illustrate the fix:

![image](https://user-images.githubusercontent.com/50068/61826617-a8252c00-ae17-11e9-8746-1770492d33d4.png)
