### PR TITLE
EventChart label based on state

### DIFF
--- a/lib/components/EventChart.js
+++ b/lib/components/EventChart.js
@@ -153,7 +153,7 @@ var EventChart = function (_React$Component) {
                         if (_underscore2.default.isString(_this2.props.label)) {
                             label = _this2.props.label;
                         } else if (_underscore2.default.isFunction(_this2.props.label)) {
-                            label = _this2.props.label(event);
+                            label = _this2.props.label(event, state);
                         }
                     }
 
@@ -169,7 +169,7 @@ var EventChart = function (_React$Component) {
                     };
 
                     var text = null;
-                    if (isHover) {
+                    if (isHover || _underscore2.default.isFunction(_this2.props.label)) {
                         text = _react2.default.createElement(
                             "g",
                             null,

--- a/src/components/EventChart.js
+++ b/src/components/EventChart.js
@@ -94,7 +94,7 @@ export default class EventChart extends React.Component {
                 if (_.isString(this.props.label)) {
                     label = this.props.label;
                 } else if (_.isFunction(this.props.label)) {
-                    label = this.props.label(event);
+                    label = this.props.label(event, state);
                 }
             }
 
@@ -110,7 +110,7 @@ export default class EventChart extends React.Component {
             };
 
             let text = null;
-            if (isHover) {
+            if (isHover || _.isFunction(this.props.label)) {
                 text = (
                     <g>
                         <rect

--- a/src/website/packages/charts/examples/outages/Index.js
+++ b/src/website/packages/charts/examples/outages/Index.js
@@ -131,7 +131,9 @@ const outages = createReactClass({
                                             series={series}
                                             size={45}
                                             style={outageEventStyleFunc}
-                                            label={e => e.get("title")}
+                                            label={(e, state) =>
+                                                state === "hover" ? e.get("title") : ""
+                                            }
                                         />
                                     </Charts>
                                 </ChartRow>

--- a/src/website/packages/charts/examples/outages/outages_docs.md
+++ b/src/website/packages/charts/examples/outages/outages_docs.md
@@ -11,7 +11,7 @@ Here we build an `EventChart`.
                 <EventChart
                     series={series}
                     style={(outageEventStyleCB)}
-                    label={e => e.get("title")} />
+                    label={(e, state) => state === 'hover' ? e.get("title") : ''} />
             </Charts>
         </ChartRow>
     </ChartContainer>


### PR DESCRIPTION
fixes #410, [as discussed](https://github.com/esnet/react-timeseries-charts/issues/410#issuecomment-524958414)

passing `state` into `label` was straightforward. i'm still checking `isHover` when `label` is a string. is that ideal?

also, i updated the outage example, so the behavior stays as it was before, only showing the `title` on hover.

let me know if i'm missing anything.