### PR TITLE
use correct form of infoStyle in defaultProps

### DIFF
--- a/src/components/EventMarker.js
+++ b/src/components/EventMarker.js
@@ -491,10 +491,17 @@ EventMarker.defaultProps = {
     infoWidth: 90,
     infoHeight: 25,
     infoStyle: {
-        fill: "white",
-        opacity: 0.9,
-        stroke: "#999",
-        pointerEvents: "none"
+      "boxStyle": {
+        "fill": "#FEFEFE",
+        "stroke": "#DDD",
+        "opacity": 0.8
+      },
+      "labelStyle": {
+        "fontSize": 11,
+        "textAnchor": "left",
+        "fill": "#b0b0b0",
+        "pointerEvents": "none"
+      }
     },
     stemStyle: {
         stroke: "#999",


### PR DESCRIPTION
EventMarker is currently not passing in the correct form to the Label component.  The latter expects an object which includes a `labelStyle` and a `boxStyle` (see https://github.com/esnet/react-timeseries-charts/blob/master/src/components/Label.js#L56).  The infoStyle that I've added reflects the current styling of labels in EventMarker and does not correspond to what is currently seen in the docs.