### PR TITLE
Update Brush to allow for mobile use with touch

### DIFF
--- a/lib/components/Brush.js
+++ b/lib/components/Brush.js
@@ -86,15 +86,22 @@ var Brush = function (_React$Component) {
         key: "handleBrushMouseDown",
         value: function handleBrushMouseDown(e) {
             e.preventDefault();
-
-            var x = e.pageX,
+            var x = void 0,
+                y = null;
+            if (e.type === 'touchstart') {
+                x = e.nativeEvent.touches[0].pageX;
+                y = e.nativeEvent.touches[0].pageY;
+            } else {
+                x = e.pageX;
                 y = e.pageY;
+            }
 
             var xy0 = [Math.round(x), Math.round(y)];
             var begin = +this.props.timeRange.begin();
             var end = +this.props.timeRange.end();
 
             document.addEventListener("mouseup", this.handleMouseUp);
+            document.addEventListener("touchend", this.handleMouseUp);
 
             this.setState({
                 isBrushing: true,
@@ -110,11 +117,16 @@ var Brush = function (_React$Component) {
             e.preventDefault();
 
             var offset = (0, _util.getElementOffset)(this.overlay);
-            var x = e.pageX - offset.left;
+            var x = void 0;
+            if (e.type === 'touchstart') {
+                x = e.nativeEvent.touches[0].pageX - offset.left;
+            } else {
+                x = e.pageX - offset.left;
+            }
             var t = this.props.timeScale.invert(x).getTime();
 
             document.addEventListener("mouseup", this.handleMouseUp);
-
+            document.addEventListener("touchend", this.handleMouseUp);
             this.setState({
                 isBrushing: true,
                 brushingInitializationSite: "overlay",
@@ -137,6 +149,8 @@ var Brush = function (_React$Component) {
 
             document.addEventListener("mouseover", this.handleMouseMove);
             document.addEventListener("mouseup", this.handleMouseUp);
+            document.addEventListener("touchend", this.handleMouseUp);
+            document.addEventListener("touchmove", this.handleMouseMove);
 
             this.setState({
                 isBrushing: true,
@@ -153,6 +167,8 @@ var Brush = function (_React$Component) {
 
             document.removeEventListener("mouseover", this.handleMouseMove);
             document.removeEventListener("mouseup", this.handleMouseUp);
+            document.removeEventListener("touchmove", this.handleMouseMove);
+            document.removeEventListener("touchend", this.handleMouseUp);
 
             this.setState({
                 isBrushing: false,
@@ -182,9 +198,15 @@ var Brush = function (_React$Component) {
         key: "handleMouseMove",
         value: function handleMouseMove(e) {
             e.preventDefault();
-
-            var x = e.pageX;
-            var y = e.pageY;
+            var x = void 0,
+                y = null;
+            if (e.type === 'touchmove' && e.nativeEvent !== undefined) {
+                x = e.nativeEvent.touches[0].pageX;
+                y = e.nativeEvent.touches[0].pageY;
+            } else {
+                x = e.pageX;
+                y = e.pageY;
+            }
             var xy = [Math.round(x), Math.round(y)];
             var viewport = this.viewport();
 
@@ -197,7 +219,7 @@ var Brush = function (_React$Component) {
 
                 if (this.state.brushingInitializationSite === "overlay") {
                     var offset = (0, _util.getElementOffset)(this.overlay);
-                    var xx = e.pageX - offset.left;
+                    var xx = x - offset.left;
                     var t = this.props.timeScale.invert(xx).getTime();
                     if (t < tb) {
                         newBegin = t < viewport.begin().getTime() ? viewport.begin() : t;
@@ -279,6 +301,8 @@ var Brush = function (_React$Component) {
                 width: width,
                 height: height,
                 style: overlayStyle,
+                onTouchStart: this.handleOverlayMouseDown,
+                onTouchEnd: this.handleMouseUp,
                 onMouseDown: this.handleOverlayMouseDown,
                 onMouseUp: this.handleMouseUp,
                 onClick: this.handleClick
@@ -340,6 +364,8 @@ var Brush = function (_React$Component) {
                 return _react2.default.createElement("rect", _extends({}, bounds, {
                     style: brushStyle,
                     pointerEvents: "all",
+                    onTouchStart: this.handleBrushMouseDown,
+                    onTouchEnd: this.handleMouseUp,
                     onMouseDown: this.handleBrushMouseDown,
                     onMouseUp: this.handleMouseUp
                 }));
@@ -403,6 +429,10 @@ var Brush = function (_React$Component) {
                     _react2.default.createElement("rect", _extends({}, leftHandleBounds, {
                         style: handleStyle,
                         pointerEvents: "all",
+                        onTouchStart: function onTouchStart(e) {
+                            return _this3.handleHandleMouseDown(e, "left");
+                        },
+                        onTouchEnd: this.handleMouseUp,
                         onMouseDown: function onMouseDown(e) {
                             return _this3.handleHandleMouseDown(e, "left");
                         },
@@ -411,6 +441,10 @@ var Brush = function (_React$Component) {
                     _react2.default.createElement("rect", _extends({}, rightHandleBounds, {
                         style: handleStyle,
                         pointerEvents: "all",
+                        onTouchStart: function onTouchStart(e) {
+                            return _this3.handleHandleMouseDown(e, "right");
+                        },
+                        onTouchEnd: this.handleMouseUp,
                         onMouseDown: function onMouseDown(e) {
                             return _this3.handleHandleMouseDown(e, "right");
                         },
@@ -423,9 +457,10 @@ var Brush = function (_React$Component) {
     }, {
         key: "render",
         value: function render() {
+            //onMouseMove={this.handleMouseMove} 
             return _react2.default.createElement(
                 "g",
-                { onMouseMove: this.handleMouseMove },
+                { onMouseMove: this.handleMouseMove, onTouchMove: this.handleMouseMove },
                 this.renderOverlay(),
                 this.renderBrush(),
                 this.renderHandles()

--- a/lib/components/Brush.js
+++ b/lib/components/Brush.js
@@ -88,7 +88,7 @@ var Brush = function (_React$Component) {
             e.preventDefault();
             var x = void 0,
                 y = null;
-            if (e.type === 'touchstart') {
+            if (e.type === "touchstart") {
                 x = e.nativeEvent.touches[0].pageX;
                 y = e.nativeEvent.touches[0].pageY;
             } else {
@@ -118,7 +118,7 @@ var Brush = function (_React$Component) {
 
             var offset = (0, _util.getElementOffset)(this.overlay);
             var x = void 0;
-            if (e.type === 'touchstart') {
+            if (e.type === "touchstart") {
                 x = e.nativeEvent.touches[0].pageX - offset.left;
             } else {
                 x = e.pageX - offset.left;
@@ -180,12 +180,12 @@ var Brush = function (_React$Component) {
         }
 
         /**
-        * Handles clearing the TimeRange if the user clicks on the overlay (but
-        * doesn't drag to create a new brush). This will send a null as the
-        * new TimeRange. The user of this code can react to that however they
-        * see fit, but the most logical response is to reset the timerange to
-        * some initial value. This behavior is optional.
-        */
+         * Handles clearing the TimeRange if the user clicks on the overlay (but
+         * doesn't drag to create a new brush). This will send a null as the
+         * new TimeRange. The user of this code can react to that however they
+         * see fit, but the most logical response is to reset the timerange to
+         * some initial value. This behavior is optional.
+         */
 
     }, {
         key: "handleClick",
@@ -200,7 +200,7 @@ var Brush = function (_React$Component) {
             e.preventDefault();
             var x = void 0,
                 y = null;
-            if (e.type === 'touchmove' && e.nativeEvent !== undefined) {
+            if (e.type === "touchmove" && e.nativeEvent !== undefined) {
                 x = e.nativeEvent.touches[0].pageX;
                 y = e.nativeEvent.touches[0].pageY;
             } else {
@@ -457,7 +457,6 @@ var Brush = function (_React$Component) {
     }, {
         key: "render",
         value: function render() {
-            //onMouseMove={this.handleMouseMove} 
             return _react2.default.createElement(
                 "g",
                 { onMouseMove: this.handleMouseMove, onTouchMove: this.handleMouseMove },
@@ -476,45 +475,45 @@ exports.default = Brush;
 
 Brush.propTypes = {
     /**
-    * The timerange for the brush. Typically you would maintain this
-    * as state on the surrounding page, since it would likely control
-    * another page element, such as the range of the main chart. See
-    * also `onTimeRangeChanged()` for receiving notification of the
-    * brush range being changed by the user.
-    *
-    * Takes a Pond TimeRange object.
-    */
+     * The timerange for the brush. Typically you would maintain this
+     * as state on the surrounding page, since it would likely control
+     * another page element, such as the range of the main chart. See
+     * also `onTimeRangeChanged()` for receiving notification of the
+     * brush range being changed by the user.
+     *
+     * Takes a Pond TimeRange object.
+     */
     timeRange: _propTypes2.default.instanceOf(_pondjs.TimeRange),
     /**
-    * The brush is rendered as an SVG rect. You can specify the style
-    * of this rect using this prop.
-    */
+     * The brush is rendered as an SVG rect. You can specify the style
+     * of this rect using this prop.
+     */
     style: _propTypes2.default.object, //eslint-disable-line
     /**
-    * The size of the invisible side handles. Defaults to 6 pixels.
-    */
+     * The size of the invisible side handles. Defaults to 6 pixels.
+     */
     handleSize: _propTypes2.default.number,
     allowSelectionClear: _propTypes2.default.bool,
     /**
-    * A callback which will be called if the brush range is changed by
-    * the user. It is called with a Pond TimeRange object. Note that if
-    * `allowSelectionClear` is set to true, then this can also be called
-    * when the user performs a simple click outside the brush area. In
-    * this case it will be called with null as the TimeRange. You can
-    * use this to reset the selection, perhaps to some initial range.
-    */
+     * A callback which will be called if the brush range is changed by
+     * the user. It is called with a Pond TimeRange object. Note that if
+     * `allowSelectionClear` is set to true, then this can also be called
+     * when the user performs a simple click outside the brush area. In
+     * this case it will be called with null as the TimeRange. You can
+     * use this to reset the selection, perhaps to some initial range.
+     */
     onTimeRangeChanged: _propTypes2.default.func,
     /**
-    * [Internal] The timeScale supplied by the surrounding ChartContainer
-    */
+     * [Internal] The timeScale supplied by the surrounding ChartContainer
+     */
     timeScale: _propTypes2.default.func,
     /**
-    * [Internal] The width supplied by the surrounding ChartContainer
-    */
+     * [Internal] The width supplied by the surrounding ChartContainer
+     */
     width: _propTypes2.default.number,
     /**
-    * [Internal] The height supplied by the surrounding ChartContainer
-    */
+     * [Internal] The height supplied by the surrounding ChartContainer
+     */
     height: _propTypes2.default.number
 };
 

--- a/src/components/Brush.js
+++ b/src/components/Brush.js
@@ -381,7 +381,6 @@ export default class Brush extends React.Component {
     }
 
     render() {
-        //onMouseMove={this.handleMouseMove}
         return (
             <g onMouseMove={this.handleMouseMove} onTouchMove={this.handleMouseMove}>
                 {this.renderOverlay()}


### PR DESCRIPTION
Fix to issue #206 

Simply updated the brush component to use:
- `touchstart`
- `touchend`
- `touchmove`

Have also had to adjust how the pageX & pageY values are retrieved based on the type (mouse or touch) due to the different events. 

This is it working on my device. 
![React-timeseries-touch-demo](https://user-images.githubusercontent.com/20455007/72213025-4c428280-34df-11ea-90d9-34269d586906.gif)

(Have run `npm run build` as required)
