### PR TITLE
Add disableWheelZoom option

### DIFF
--- a/lib/components/ChartContainer.js
+++ b/lib/components/ChartContainer.js
@@ -547,6 +547,7 @@ var ChartContainer = function (_React$Component) {
                         scale: timeScale,
                         enablePanZoom: this.props.enablePanZoom,
                         enableDragZoom: this.props.enableDragZoom,
+                        disableWheelZoom: this.props.disableWheelZoom,
                         minDuration: this.props.minDuration,
                         minTime: this.props.minTime,
                         maxTime: this.props.maxTime,
@@ -654,6 +655,13 @@ ChartContainer.propTypes = {
      * Boolean to turn on interactive drag to zoom behavior for the chart.
      */
     enableDragZoom: _propTypes2.default.bool,
+
+    /**
+     * Boolean to turn off scroll wheel to zoom behavior for the chart.
+     * By default, scroll wheel zooming is enabled if enableDragZoom or
+     * enablePanZoom are true.
+     */
+    disableWheelZoom: _propTypes2.default.bool,
 
     /**
      * If this is set the timerange of the chart cannot be zoomed in further
@@ -870,6 +878,7 @@ ChartContainer.defaultProps = {
     padding: 0,
     enablePanZoom: false,
     enableDragZoom: false,
+    disableWheelZoom: false,
     utc: false,
     showGrid: false,
     showGridPosition: "over",

--- a/lib/components/EventHandler.js
+++ b/lib/components/EventHandler.js
@@ -99,7 +99,7 @@ var EventHandler = function (_React$Component) {
     }, {
         key: "handleScrollWheel",
         value: function handleScrollWheel(e) {
-            if (!this.props.enablePanZoom && !this.props.enableDragZoom) {
+            if (this.props.disableWheelZoom || !this.props.enablePanZoom && !this.props.enableDragZoom) {
                 return;
             }
 
@@ -385,6 +385,7 @@ EventHandler.propTypes = {
     children: _propTypes2.default.oneOfType([_propTypes2.default.arrayOf(_propTypes2.default.node), _propTypes2.default.node]),
     enablePanZoom: _propTypes2.default.bool,
     enableDragZoom: _propTypes2.default.bool,
+    disableWheelZoom: _propTypes2.default.bool,
     scale: _propTypes2.default.func.isRequired,
     width: _propTypes2.default.number.isRequired,
     height: _propTypes2.default.number.isRequired,
@@ -400,5 +401,6 @@ EventHandler.propTypes = {
 
 EventHandler.defaultProps = {
     enablePanZoom: false,
-    enableDragZoom: false
+    enableDragZoom: false,
+    disableWheelZoom: false
 };

--- a/src/components/ChartContainer.js
+++ b/src/components/ChartContainer.js
@@ -495,6 +495,7 @@ export default class ChartContainer extends React.Component {
                     scale={timeScale}
                     enablePanZoom={this.props.enablePanZoom}
                     enableDragZoom={this.props.enableDragZoom}
+                    disableWheelZoom={this.props.disableWheelZoom}
                     minDuration={this.props.minDuration}
                     minTime={this.props.minTime}
                     maxTime={this.props.maxTime}
@@ -602,6 +603,13 @@ ChartContainer.propTypes = {
      * Boolean to turn on interactive drag to zoom behavior for the chart.
      */
     enableDragZoom: PropTypes.bool,
+
+    /**
+     * Boolean to turn off scroll wheel to zoom behavior for the chart.
+     * By default, scroll wheel zooming is enabled if enableDragZoom or
+     * enablePanZoom are true.
+     */
+    disableWheelZoom: PropTypes.bool,
 
     /**
      * If this is set the timerange of the chart cannot be zoomed in further
@@ -823,6 +831,7 @@ ChartContainer.defaultProps = {
     padding: 0,
     enablePanZoom: false,
     enableDragZoom: false,
+    disableWheelZoom: false,
     utc: false,
     showGrid: false,
     showGridPosition: "over",

--- a/src/components/EventHandler.js
+++ b/src/components/EventHandler.js
@@ -60,7 +60,10 @@ export default class EventHandler extends React.Component {
     //
 
     handleScrollWheel(e) {
-        if (!this.props.enablePanZoom && !this.props.enableDragZoom) {
+        if (
+            this.props.disableWheelZoom ||
+            (!this.props.enablePanZoom && !this.props.enableDragZoom)
+        ) {
             return;
         }
 
@@ -338,6 +341,7 @@ EventHandler.propTypes = {
     children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]),
     enablePanZoom: PropTypes.bool,
     enableDragZoom: PropTypes.bool,
+    disableWheelZoom: PropTypes.bool,
     scale: PropTypes.func.isRequired,
     width: PropTypes.number.isRequired,
     height: PropTypes.number.isRequired,
@@ -353,5 +357,6 @@ EventHandler.propTypes = {
 
 EventHandler.defaultProps = {
     enablePanZoom: false,
-    enableDragZoom: false
+    enableDragZoom: false,
+    disableWheelZoom: false
 };

--- a/src/website/packages/charts/api/docs.json
+++ b/src/website/packages/charts/api/docs.json
@@ -1887,6 +1887,17 @@
           "computed": false
         }
       },
+      "disableWheelZoom": {
+        "type": {
+          "name": "bool"
+        },
+        "required": false,
+        "description": "Boolean to turn off interactive mouse wheel to zoom behavior for the chart.",
+        "defaultValue": {
+          "value": "false",
+          "computed": false
+        }
+      },
       "minDuration": {
         "type": {
           "name": "number"
@@ -2746,6 +2757,17 @@
         },
         "required": false,
         "description": "",
+        "defaultValue": {
+          "value": "false",
+          "computed": false
+        }
+      },
+      "disableWheelZoom": {
+        "type": {
+          "name": "bool"
+        },
+        "required": false,
+        "description": "Boolean to turn off interactive mouse wheel to zoom behavior for the chart.",
         "defaultValue": {
           "value": "false",
           "computed": false


### PR DESCRIPTION
The mouse wheel zooming doesn't work well with pages with many charts, as it interferes with page scrolling. This adds the ability to disable it even if `enablePanZoom` or `enableDragZoom` are active.