### PR TITLE
Change label proptypes to allow for anything that can be rendered

### DIFF
--- a/src/components/Legend.js
+++ b/src/components/Legend.js
@@ -450,7 +450,7 @@ Legend.propTypes = {
     categories: PropTypes.arrayOf(
         PropTypes.shape({
             key: PropTypes.string.isRequired, // eslint-disable-line
-            label: PropTypes.string.isRequired, // eslint-disable-line
+            label: PropTypes.node.isRequired, // eslint-disable-line
             disabled: PropTypes.bool, // eslint-disable-line
             style: PropTypes.object, // eslint-disable-line
             labelStyle: PropTypes.object // eslint-disable-line


### PR DESCRIPTION
 In my projects, I pass a JSX element instead of a string and it renders but the console displays a proptype error. The label prop is a child of a div in the legend. Numbers, strings, elements are all valid items that can be rendered.